### PR TITLE
Build the theme with a Lua template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Both the Vimscript theme and the help text file are generated with a
+lightweight, custom templating system, written in Lua. There's a `Makefile`
+which generates these. You should be able to just run `make` to re-generate the
+two files.
+
+For Nix users, there's also a Flake: `nix build .#yui` does the trick.
+
+If you're only adding or modifying highlight groups and options, you should be
+able to stick to `template/yui.lua`, which is where all highlight groups are
+defined.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: all
+all: colors/yui.vim doc/yui.txt
+
+colors/yui.vim: template/*.lua
+	@mkdir -p colors
+	LUA_PATH="template/?.lua" lua template/gen_theme.lua > $@
+
+doc/yui.txt: template/*.lua
+	@mkdir -p doc
+	LUA_PATH="template/?.lua" lua template/gen_docs.lua > $@
+
+.PHONY: clean
+clean:
+	@rm -f colors/yui.vim doc/yui.txt

--- a/README.md
+++ b/README.md
@@ -1,66 +1,31 @@
 # YUI
 
-## Intro
+A truly minimal color scheme inspired by the [Field Notes "Rams"
+Notebook](https://fieldnotesbrand.com/products/rams).
 
-Experimental color scheme without any colors, except what's required to display a meaningful `diff`.
-All syntax differentiation is achieved through font styles, so your terminal needs to support bold and italic text.
+## Documentation
 
-Shades are used for things like dimming folded text.
+Please check [the plugin documentation in the help text](./doc/yui.txt) with
+`:h yui.txt`
 
 ## Supported Plugins
 
+Make sure to check [the plugin documentation in the help text](./doc/yui.txt)
+with `h:yui.txt` for further information on some of these integrations.
+
 - `nvim-hlslens`
-- `lightline`: if you use `lightline` and have `yui` set as a color scheme,
-  `yui` will automatically set the `lightline` color palette (see `yui_lightline` option)
+- `lightline`
+- `fugitive`
 - `dirvish`
 - `vim-sneak`
 - `gitsigns`
 - `conflict-marker.vim`
 - `which-key`
+- `leap`
 
-## Options
+## Contributing
 
-This information can also be found in the help, `:help yui`
-
-### `g:yui_lightline`
-
-- `v:false` (**default**): do not register the `yui` palette with `lightline`
-- `v:true`: register the `yui` palette with `lightline`. You still need
-  to set the lightline color scheme to `yui`.
-
-```vimscript
-let g:yui_lightline = v:true
-colorscheme yui
-let g:lightline = {
-  \ 'colorscheme': 'yui'
-  \ }
-```
-
-### `g:yui_folds`
-
-- `fade` (**default**): makes folded text less visible
-- `emphasize`: gives folded text a distinct background color
-
-### `g:yui_line_numbers`
-
-- `fade` (**default**): makes line numbers and signcolumn text less visible
-- `emphasize`: gives line numbers and signcolumn text a distinct background color
-
-### `g:yui_comments`
-
-`g:yui_emphasized_comments` takes precedence for backwards compatibility
-
-- `fade`: makes comments less visible
-- `emphasize`: makes comments more visible and is equivalent to `yui_emphasized_comments = 1`
-- `normal` (**default**): does not affect comment visibility
-- `bg`: make comments stand out by giving them a background. Text is not italic.
-
-### `g:yui_emphasized_comments`
-
-**DEPRECATED**: Use `g:yui_comments` instead
-
-- `1`: comments are orange
-- `0` (**default**): comments are faded, as before
+Please see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Screenshots
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,3 @@
+- [x] Remove italic from comments that are already colored. Italic comments
+  means ASCII art is hard.
+- [ ] Update screenshots

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -1,31 +1,3 @@
-" https://hslpicker.com/
-" | Color             | HEX    | Number | HSL                  | Notes      |
-" | ----------------- | ------ | ------ | -------------------- | ---------- |
-" | black_15          | 292523 | 236    | hsl(20°,  8%,   15%) |            |
-" | black_36          | 635954 | 241    | hsl(20°,  8%,   36%) | FOREGROUND |
-" | black_46          | 7f726c | 246    | hsl(20°,  8%,   46%) |            |
-" | black_68          | b4aba7 | 249    | hsl(20°,  8%,   68%) |            |
-" | green_25          | 408000 | 70     | hsl(90°,  100%, 25%) |            |
-" | green_91          | e8ffd1 | 193    | hsl(90°,  100%, 91%) |            |
-" | orange_51         | E44C22 | 166    | hsl(13°,  78%,  51%) |            |
-" | red_36            | a7111d | 124    | hsl(355°, 82%,  36%) |            |
-" | red_94            | fce3e5 | 224    | hsl(355°, 82%,  94%) |            |
-" | yellow_26         | 7c8500 | 94     | hsl(64°,  100%, 26%) |            |
-" | yellow_82         | f9ffa3 | 229    | hsl(64°,  100%, 82%) |            |
-" | purple_45         | 371ec8 | 19     | hsl(249°, 74%,  45%) |            |
-" | purple_55         | 5137e1 | 62     | hsl(249°, 74%,  55%) |            |
-" | purple_65         | 7864e8 | 99     | hsl(249°, 74%,  65%) |            |
-" | purple_87         | cdc5f6 | 147    | hsl(249,  74%,  87%) |            |
-" | purple_91         | DCD7F9 | 189    | hsl(249°, 74%,  91%) |            |
-" | blue_91           | d8ebf8 | 195    | hsl(205°, 69%,  91%) |            |
-" | blue_28           | 165079 | 25     | hsl(205°, 69%,  28%) |            |
-" | white_75          | cfbfb0 | 251    | hsl(30°,  24%,  75%) |            |
-" | white_82          | dcd1c6 | 252    | hsl(30°,  24%,  82%) |            |
-" | white_88          | e8e0d9 | 253    | hsl(30°,  24%,  88%) |            |
-" | white_92          | efeae5 | 254    | hsl(30°,  24%,  92%) | BACKGROUND |
-" | white_98          | fbfaf9 | 255    | hsl(30°,  24%,  98%) |            |
-" | cyan_23           | 007575 | 66     | hsl(180°, 100%, 23%) |            |
-
 set background=light
 
 if !has('gui_running') && &t_Co < 256 && !has('nvim')
@@ -38,351 +10,379 @@ if exists('syntax_on')
 endif
 
 let g:colors_name = 'yui'
-
-"===============================
-"=       BUILT IN COLORS       =
-"===============================
-
+  
 if has('nvim')
-  let g:terminal_color_0 = '#635954'
-  let g:terminal_color_1 = '#a7111d'
-  let g:terminal_color_2 = '#408000'
-  let g:terminal_color_3 = '#7c8500'
-  let g:terminal_color_4 = '#00588f'
-  let g:terminal_color_5 = '#5137e1'
-  let g:terminal_color_6 = '#007575'
-  let g:terminal_color_7 = '#efeae5'
-  let g:terminal_color_8 = '#635954'
-  let g:terminal_color_9 = '#a7111d'
-  let g:terminal_color_10 = '#408000'
-  let g:terminal_color_11 = '#7c8500'
-  let g:terminal_color_12 = '#00588f'
-  let g:terminal_color_13 = '#7864e8'
-  let g:terminal_color_14 = '#007575'
-  let g:terminal_color_15 = '#efeae5'
+	let g:terminal_color_0 = '#5f503e'
+	let g:terminal_color_1 = '#f8acac'
+	let g:terminal_color_2 = '#4e4b36'
+	let g:terminal_color_3 = '#7c4f18'
+	let g:terminal_color_4 = '#00588f'
+	let g:terminal_color_5 = '#6132d7'
+	let g:terminal_color_6 = '#4a5054'
+	let g:terminal_color_7 = '#f6f3f0'
+	let g:terminal_color_8 = '#5f503e'
+	let g:terminal_color_9 = '#f8acac'
+	let g:terminal_color_10 = '#4e4b36'
+	let g:terminal_color_11 = '#7c4f18'
+	let g:terminal_color_12 = '#00588f'
+	let g:terminal_color_13 = '#8368e7'
+	let g:terminal_color_14 = '#4a5054'
+	let g:terminal_color_15 = '#f6f3f0'
 else
   let g:terminal_ansi_colors = [
-  \'#635954',
-  \'#a7111d',
-  \'#408000',
-  \'#7c8500',
-  \'#00588f',
-  \'#5137e1',
-  \'#007575',
-  \'#efeae5',
-  \'#635954',
-  \'#a7111d',
-  \'#408000',
-  \'#7c8500',
-  \'#00588f',
-  \'#7864e8',
-  \'#007575',
-  \'#efeae5']
+	\'#5f503e',
+	\'#f8acac',
+	\'#4e4b36',
+	\'#7c4f18',
+	\'#00588f',
+	\'#6132d7',
+	\'#4a5054',
+	\'#f6f3f0',
+	\'#5f503e',
+	\'#f8acac',
+	\'#4e4b36',
+	\'#7c4f18',
+	\'#00588f',
+	\'#8368e7',
+	\'#4a5054',
+	\'#f6f3f0']
 endif
+  
 
-"======== UI COLORS =========
+" UI & Syntax
+hi Normal guifg=#5f503e ctermfg=239 guibg=#f6f3f0 ctermbg=255
+hi! link Boolean Constant
+hi! link Character Constant
+hi ColorColumn guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254
+hi Conceal guifg=#d6c7b6 ctermfg=187 guibg=NONE ctermbg=NONE
+hi! link Conditional Statement
+hi Constant guifg=#453a2c ctermfg=237 guibg=NONE ctermbg=NONE
+hi CurSearch guifg=#dcd7f9 ctermfg=189 guibg=#8368e7 ctermbg=98
+hi Cursor guifg=bg ctermfg=bg guibg=fg ctermbg=fg
+hi CursorColumn guifg=NONE ctermfg=NONE guibg=#fdfcfb ctermbg=231
+hi CursorIM guifg=NONE ctermfg=NONE guibg=fg ctermbg=fg
+hi CursorLine guifg=fg ctermfg=fg guibg=#fdfcfb ctermbg=231
+hi CursorLineNr guifg=fg ctermfg=fg guibg=#fdfcfb ctermbg=231
+hi! link Debug Special
+hi! link Define PreProc
+hi! link Delimiter Special
+hi DiffAdd guifg=#4e4b36 ctermfg=238 guibg=#e2dba3 ctermbg=187
+hi DiffChange guifg=#7c4f18 ctermfg=94 guibg=#fef0e8 ctermbg=255
+hi DiffDelete guifg=#350303 ctermfg=233 guibg=#f8acac ctermbg=217 gui=NONE cterm=NONE
+hi DiffText guifg=#4a5054 ctermfg=239 guibg=#d9e0e3 ctermbg=253
+hi Directory guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link EndOfBuffer NonText
+hi! link Error DiffDelete
+hi! link ErrorMessage DiffDelete
+hi! link ErrorMsg DiffDelete
+hi Exception guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link Float Number
+hi! link Function Identifier
+hi Identifier guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Ignore guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi IncSearch guifg=#dcd7f9 ctermfg=189 guibg=#6132d7 ctermbg=62
+hi! link Include PreProc
+hi InfoMsg guifg=#6132d7 ctermfg=62 guibg=#dcd7f9 ctermbg=189
+hi Keyword guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Label guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link Macro PreProc
+hi MatchParen guifg=NONE ctermfg=NONE guibg=#e0d5ca ctermbg=188
+hi Menu guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254
+hi ModeMsg guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi MoreMsg guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link MsgArea Normal
+hi! link MsgSeparator VertSplit
+hi NonText guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link NormalNC Normal
+hi! link NormalNC Normal
+hi! link Number Constant
+hi Operator guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Pmenu guifg=NONE ctermfg=NONE guibg=#ebe4dd ctermbg=254
+hi! link PmenuSbar Pmenu
+hi! link PmenuSel WildMenu
+hi PmenuThumb guifg=NONE ctermfg=NONE guibg=fg ctermbg=fg
+hi! link PreCondit PreProc
+hi PreProc guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Question guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link QuickFixLine Search
+hi Repeat guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Scrollbar guifg=NONE ctermfg=NONE guibg=#ebe4dd ctermbg=254
+hi Search guifg=#6132d7 ctermfg=62 guibg=#dcd7f9 ctermbg=189
+hi Special guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link SpecialChar Special
+hi! link SpecialComment Special
+hi SpecialKey guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link SpellBad DiffDelete
+hi SpellCap guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE guisp=#f8acac gui=undercurl cterm=undercurl
+hi SpellLocal guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi SpellRare guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Statement guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi StatusLine guifg=#e0d5ca ctermfg=188 guibg=#453a2c ctermbg=237 gui=reverse cterm=reverse
+hi StatusLineNC guifg=#ebe4dd ctermfg=254 guibg=#5f503e ctermbg=239
+hi! link StatusLineTerm StatusLine
+hi! link StatusLineTermNC StatusLineNC
+hi! link StorageClass Type
+hi! link String Constant
+hi! link Structure Type
+hi! link Substitute IncSearch
+hi! link TabLine Pmenu
+hi! link TabLineFill StatusLineNC
+hi TabLineSel guifg=fg ctermfg=fg guibg=#e0d5ca ctermbg=188
+hi! link Tag Special
+hi Terminal guifg=fg ctermfg=fg guibg=bg ctermbg=bg
+hi Title guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link Todo WarningMsg
+hi ToolbarButton guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi ToolbarLine guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi Tooltip guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254
+hi Type guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi! link Typedef Type
+hi Underlined guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi VertSplit guifg=#d6c7b6 ctermfg=187 guibg=NONE ctermbg=NONE
+hi Visual guifg=#3b1c89 ctermfg=54 guibg=#b4a8f2 ctermbg=147
+hi VisualNOS guifg=NONE ctermfg=NONE guibg=#fdfcfb ctermbg=231
+hi! link WarningMsg DiffChange
+hi Whitespace guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
+hi! link WildMenu Visual
+hi! link WinBar TabLineSel
+hi! link WinBarNC TabLine
+hi jsParensError guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link lCursor Cursor
 
-hi        Normal                      guifg=#635954 ctermfg=241  guibg=#efeae5 ctermbg=254  guisp=NONE    gui=NONE      cterm=NONE
-hi        MsgArea                     guifg=#7f726c ctermfg=246  guibg=#e8e0d9 ctermbg=253  guisp=NONE    gui=NONE      cterm=NONE
-hi        ColorColumn                 guifg=fg      ctermfg=fg   guibg=#e8e0d9 ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Conceal                     guifg=#cfbfb0 ctermfg=251  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Constant                    guifg=#292523 ctermfg=236  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        CursorColumn                guifg=NONE    ctermfg=NONE guibg=#fbfaf9 ctermbg=255  guisp=NONE    gui=NONE      cterm=NONE
-hi        Cursor                      guifg=bg      ctermfg=bg   guibg=fg      ctermbg=fg   guisp=NONE    gui=NONE      cterm=NONE
-hi        CursorIM                    guifg=NONE    ctermfg=NONE guibg=fg      ctermbg=fg   guisp=NONE    gui=NONE      cterm=NONE
-hi        CursorLine                  guifg=fg      ctermfg=fg   guibg=#fbfaf9 ctermbg=255  guisp=NONE    gui=NONE      cterm=NONE
-hi        CursorLineNr                guifg=fg      ctermfg=fg   guibg=#fbfaf9 ctermbg=255  guisp=NONE    gui=NONE      cterm=NONE
-hi        DiffAdd                     guifg=#408000 ctermfg=70   guibg=#e8ffd1 ctermbg=193  guisp=NONE    gui=NONE      cterm=NONE
-hi        DiffChange                  guifg=#7c8500 ctermfg=94   guibg=#f9ffa3 ctermbg=229  guisp=NONE    gui=NONE      cterm=NONE
-hi        DiffDelete                  guifg=#a7111d ctermfg=124  guibg=#fce3e5 ctermbg=224  guisp=NONE    gui=NONE      cterm=NONE
-hi        DiffText                    guifg=#165079 ctermfg=25   guibg=#d8ebf8 ctermbg=195  guisp=NONE    gui=NONE      cterm=NONE
-hi        Directory                   guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Error                       guifg=#a7111d ctermfg=124  guibg=#fce3e5 ctermbg=224  guisp=NONE    gui=NONE      cterm=NONE
-hi        ErrorMsg                    guifg=#a7111d ctermfg=124  guibg=#fce3e5 ctermbg=224  guisp=NONE    gui=NONE      cterm=NONE
-hi        Identifier                  guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Ignore                      guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        IncSearch                   guifg=#DCD7F9 ctermfg=189  guibg=#5137e1 ctermbg=62   guisp=NONE    gui=NONE      cterm=NONE
-hi        InfoMsg                     guifg=#5137e1 ctermfg=62   guibg=#DCD7F9 ctermbg=189  guisp=NONE    gui=NONE      cterm=NONE
-hi        MatchParen                  guifg=NONE    ctermfg=NONE guibg=#dcd1c6 ctermbg=252  guisp=NONE    gui=bold      cterm=bold
-hi        TabLine                     guifg=fg      ctermfg=fg   guibg=bg      ctermbg=bg   guisp=NONE    gui=NONE      cterm=NONE
-hi        ModeMsg                     guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        MoreMsg                     guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        NonText                     guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Pmenu                       guifg=NONE    ctermfg=NONE guibg=#e8e0d9 ctermbg=253  guisp=NONE    gui=NONE      cterm=NONE
-hi        PmenuThumb                  guifg=NONE    ctermfg=NONE guibg=fg      ctermbg=fg   guisp=NONE    gui=NONE      cterm=NONE
-hi        PreProc                     guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Question                    guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Search                      guifg=#5137e1 ctermfg=62   guibg=#DCD7F9 ctermbg=189  guisp=NONE    gui=NONE      cterm=NONE
-hi        CurSearch                   guifg=#DCD7F9 ctermfg=189  guibg=#7864e8 ctermbg=99   guisp=NONE    gui=NONE      cterm=NONE
-hi        Visual                      guifg=#371ec8 ctermfg=19   guibg=#cdc5f6 ctermbg=147  guisp=NONE    gui=NONE      cterm=NONE
-hi        Special                     guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        SpecialKey                  guifg=#b4aba7 ctermfg=249  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        SpellBad                    guifg=#a7111d ctermfg=124  guibg=#fce3e5 ctermbg=224  guisp=NONE    gui=NONE      cterm=NONE
-hi        SpellCap                    guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=#a7111d gui=undercurl cterm=undercurl
-hi        SpellLocal                  guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        SpellRare                   guifg=fg      ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Statement                   guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-hi        StatusLine                  guifg=bg      ctermfg=bg   guibg=fg      ctermbg=fg   guisp=NONE    gui=bold      cterm=NONE
-hi        StatusLineNC                guifg=fg      ctermfg=fg   guibg=#dcd1c6 ctermbg=252  guisp=NONE    gui=NONE      cterm=NONE
-hi        Terminal                    guifg=fg      ctermfg=fg   guibg=bg      ctermbg=bg   guisp=NONE    gui=NONE      cterm=NONE
-hi        Todo                        guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=underline cterm=underline
-hi        ToolbarButton               guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        ToolbarLine                 guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Type                        guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-hi        Underlined                  guifg=fg      ctermfg=fg   guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        VertSplit                   guifg=#cfbfb0 ctermfg=251  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        VisualNOS                   guifg=NONE    ctermfg=NONE guibg=#fbfaf9 ctermbg=255  guisp=NONE    gui=NONE      cterm=NONE
-hi        WarningMsg                  guifg=#7c8500 ctermfg=94   guibg=#f9ffa3 ctermbg=229  guisp=NONE    gui=NONE      cterm=NONE
-hi        Whitespace                  guifg=#b4aba7 ctermfg=249  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi        Tooltip                     guifg=fg                   guibg=#e8e0d9
-hi        Menu                        guifg=fg                   guibg=#e8e0d9
-hi        Scrollbar                   guifg=NONE                 guibg=#e8e0d9
-hi        Title                       guifg=fg ctermfg=fg        guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-hi!  link NormalNC         Normal
-hi!  link WinBar           TabLineSel
-hi!  link WinBarNC         TabLine
-hi!  link MsgSeparator     VertSplit
-hi!  link EndOfBuffer      NonText
-hi!  link QuickFixLine     Search
-hi!  link diffAdded        DiffAdd
-hi!  link diffChanged      DiffChange
-hi!  link diffRemoved      DiffDelete
-hi!  link diffComment      Comment
-hi!  link PmenuSel         WildMenu
-hi!  link StatusLineTerm   StatusLine
-hi!  link StatusLineTermNC StatusLineNC
-hi!  link TabLineSel       Search
-hi!  link TabLineFill      TabLine
-hi!  link lCursor          Cursor
-hi!  link PmenuSbar        Pmenu
-hi!  link WildMenu         Visual
+" Floating Windows
+hi FloatBorder guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254
+hi FloatTitle guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254 gui=bold cterm=bold
+hi NormalFloat guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254
 
-let folds = get(g:, 'yui_folds', 'fade')
-if folds ==? 'emphasize'
-  hi FoldColumn               guifg=#7f726c ctermfg=243  guibg=#dcd1c6 ctermbg=254  guisp=NONE    gui=NONE      cterm=NONE
-  hi Folded                   guifg=#7f726c ctermfg=243  guibg=#dcd1c6 ctermbg=254  guisp=NONE    gui=NONE      cterm=NONE
-elseif folds ==? 'fade'
-  hi FoldColumn               guifg=#b4aba7 ctermfg=181  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-  hi Folded                   guifg=#b4aba7 ctermfg=181  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-endif
+" Diagnostic
+hi! link DiagnosticError Error
+hi DiagnosticHint guifg=#5f503e ctermfg=239 guibg=NONE ctermbg=NONE
+hi! link DiagnosticInfo DiffText
+hi DiagnosticSignError guifg=#350303 ctermfg=233 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi DiagnosticSignHint guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi DiagnosticSignInfo guifg=#4a5054 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi DiagnosticSignWarn guifg=#7c4f18 ctermfg=94 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi! link DiagnosticUnderlineError Error
+hi! link DiagnosticUnderlineHint Normal
+hi! link DiagnosticUnderlineInfo DiffText
+hi! link DiagnosticUnderlineWarn WarningMsg
+hi! link DiagnosticWarn WarningMsg
 
-let linenr = get(g:, 'yui_line_numbers', 'fade')
-if linenr ==? 'emphasize'
-  hi SignColumn               guifg=#7f726c ctermfg=243  guibg=#dcd1c6 ctermbg=254  guisp=NONE    gui=NONE      cterm=NONE
-  hi LineNr                   guifg=#7f726c ctermfg=243  guibg=#dcd1c6 ctermbg=254  guisp=NONE    gui=NONE      cterm=NONE
-elseif linenr ==? 'fade'
-  hi SignColumn               guifg=fg      ctermfg=fg   guibg=bg      ctermbg=255  guisp=NONE    gui=NONE      cterm=NONE
-  hi LineNr                   guifg=#b4aba7 ctermfg=181  guibg=NONE    ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-endif
-
-let comments = get(g:, 'yui_comments', 'normal')
-if comments ==? 'emphasize' || get(g:, 'yui_emphasized_comments', 0)
-  hi Comment                  guifg=#E44C22 ctermfg=196  guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-elseif comments ==? 'fade'
-  hi Comment                  guifg=#7f726c ctermfg=181  guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-elseif comments ==? 'normal'
-  hi Comment                  guifg=#7f726c ctermfg=241  guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-elseif comments ==? 'bg'
-  hi Comment                  guifg=fg      ctermfg=fg  guibg=#e8e0d9 ctermbg=NONE guisp=NONE    gui=NONE      cterm=NONE
-endif
-
-"======== LSP ===============
-" Check :help diagnostic-highlights
-"
-" > By default, highlights for signs, floating windows, and virtual text are
-" > linked to the corresponding default highlight. Underline highlights are
-" > not linked and use their own default highlight groups.
-"
-" > For example, the default highlighting for |hl-DiagnosticSignError| is linked
-" > to |hl-DiagnosticError|.
-
-hi! link DiagnosticError           Error
-hi! link DiagnosticWarn             WarningMsg
-hi! link DiagnosticInfo             DiffText
-hi DiagnosticHint                                guifg=#635954 ctermfg=241  guibg=NONE ctermbg=NONE  guisp=NONE    gui=NONE      cterm=NONE
-hi! link DiagnosticUnderlineError   Error
-hi! link DiagnosticUnderlineWarn    WarningMsg
-hi! link DiagnosticUnderlineInfo    DiffText
-hi! link DiagnosticUnderlineHint    Normal
+" LSP
 hi! link LspSignatureActiveParameter Search
 
-"======== SYNTAX ============
+" Vim Script
+hi! link vimGroup Normal
+hi! link vimHiCTerm Normal
+hi! link vimHiCTermFgBg Normal
+hi! link vimHiGroup Normal
+hi! link vimHiGui Normal
+hi! link vimHiGuiFgBg Normal
+hi! link vimHiKeyList Normal
 
-hi! link Boolean          Constant
-hi! link Character        Constant
-hi! link Conditional      Statement
-hi! link Define           PreProc
-hi! link Debug            Special
-hi! link Delimiter        Special
-hi! link Float            Number
-hi! link Function         Identifier
-hi! link Include          PreProc
-hi! link Macro            PreProc
-hi! link Number           Constant
-hi! link PreCondit        PreProc
-hi! link SpecialChar      Special
-hi! link SpecialComment   Special
-hi! link StorageClass     Type
-hi! link String           Constant
-hi! link Structure        Type
-hi! link Tag              Special
-hi! link Typedef          Type
-hi! link Substitute       IncSearch
-hi       Operator                     guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
-hi       Repeat                       guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
-hi       jsParensError                guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
-hi       Exception                    guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
-hi       Keyword                      guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
-hi       Label                        guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE gui=NONE cterm=NONE
+" Typescript
+hi typescriptParens guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 
-"======== Vim Script ========
-" v-- Some of these are normally linked to Type, which is italicized, leading
-" to lots of italics in this file
-hi! link vimGroup                     Normal
-hi! link vimHiGui                     Normal
-hi! link vimHiKeyList                 Normal
-hi! link vimHiGroup                   Normal
-hi! link vimHiCTerm                   Normal
-hi! link vimHiCTermFgBg               Normal
-hi!  link                     vimHiGuiFgBg  Normal
+" Markdown
+hi markdownBold guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi markdownBoldDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi markdownBoldItalicDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi markdownCodeDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi! link markdownH1 mkdHeading
+hi! link markdownH1Delimiter markdownHeadingDelimiter
+hi! link markdownH2 mkdHeading
+hi! link markdownH3 mkdHeading
+hi! link markdownH4 mkdHeading
+hi markdownHeadingDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi! link markdownItalic mkItalic
+hi markdownItalicDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi markdownLinkDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi markdownLinkText guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi markdownLinkTextDelimiter guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
+hi markdownUrl guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi markdownUrl guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi mkCode guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi mkHeading guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi mkItalic guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi! link mkdCodeDelimiter mkCode
 
-"======== Markdown ==========
-hi  mkdHeading               guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=underline cterm=underline
-hi  mkdItalic                guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=italic    cterm=italic
-hi  markdownBold             guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=bold      cterm=bold
-hi  markdownUrl              guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=underline cterm=underline
-hi  markdownHeadingDelimiter guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=underline cterm=NONE
-hi  mkdCode                           guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE    gui=NONE      cterm=NONE
-hi  mkdCodeDelimiter                  guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE    gui=NONE      cterm=NONE
-hi! link markdownItalic               mkdItalic
-hi  markdownLinkText                  guifg=fg ctermfg=fg  guibg=NONE ctermbg=NONE  guisp=NONE    gui=NONE      cterm=NONE
-hi! link markdownH1                   mkdHeading
-hi! link markdownH1Delimiter          markdownHeadingDelimiter
-hi! link markdownH2                   mkdHeading
-hi! link markdownH3                   mkdHeading
-hi! link markdownH4                   mkdHeading
-hi! link markdownCodeDelimiter        folded
-hi! link markdownBoldDelimiter        folded
-hi! link markdownItalicDelimiter      folded
-hi! link markdownBoldItalicDelimiter  folded
-hi! link markdownLinkDelimiter        folded
-hi! link markdownLinkTextDelimiter    folded
+" Help Text
+hi! link helpBacktick Constant
+hi! link helpCommand Constant
+hi! link helpDeprecated Error
+hi helpExample guifg=#453a2c ctermfg=237 guibg=#ebe4dd ctermbg=254 gui=NONE cterm=NONE
+hi helpHeader guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi helpHeadline guifg=#453a2c ctermfg=237 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi helpHyperTextEntry guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi helpHyperTextJump guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi helpNote guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi helpOption guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi helpSectionDelim guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi helpSpecial guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi helpURL guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
 
-"======== Help Text =========
-hi   helpHyperTextJump        guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=underline cterm=underline
-hi   helpHeadline             guifg=NONE    ctermfg=NONE guibg=NONE    ctermbg=NONE guisp=NONE    gui=bold      cterm=bold
-hi! link helpExample                  Normal
-hi! link helpCommand                  Constant
-hi! link helpBacktick                 Constant
+" Help Text TS
+hi! link @text.literal helpExample
+hi! link @text.reference helpOption
 
-"======== XML ===============
+" XML
 hi! link xmlProcessingDelim Normal
-hi xmlTagName guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE guisp=NONE gui=NONE cterm=NONE
+hi xmlTagName guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
-"===============================
-"=           PLUGINS           =
-"===============================
+" fugitive
+hi! link diffAdded DiffAdd
+hi! link diffChanged DiffChange
+hi! link diffComment Comment
+hi diffLine guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi! link diffRemoved DiffDelete
+hi diffSubname guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi fugitiveStagedSection guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold
+hi fugitiveUnstagedSection guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold
+hi gitHashAbbrev guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
 
-"======== gitsigns ==========
-hi! link GitSignsAdd                  DiffAdd
-hi! link GitSignsAddNr                DiffAdd
-hi! link GitSignsAddLn                DiffAdd
-hi! link GitSignsChange               DiffChange
-hi! link GitSignsChangeNr             DiffChange
-hi! link GitSignsChangeLn             DiffChange
-hi! link GitSignsDelete               DiffDelete
-hi! link GitSignsDeleteNr             DiffDelete
-hi! link GitSignsDeleteLn             DiffDelete
+" Git Signs
+hi! link GitSignsAdd DiffAdd
+hi! link GitSignsAddLn DiffAdd
+hi! link GitSignsAddNr DiffAdd
+hi! link GitSignsChange DiffChange
+hi! link GitSignsChangeLn DiffChange
+hi! link GitSignsChangeNr DiffChange
+hi! link GitSignsDelete DiffDelete
+hi! link GitSignsDeleteLn DiffDelete
+hi! link GitSignsDeleteNr DiffDelete
 
-"======== indentline ========
-hi! link IndentBlanklineChar          VertSplit
+" Indent Blank Line
+hi! link IndentBlanklineChar VertSplit
 
-"======== vim-sneak =========
-hi! link Sneak                        Visual
-hi! link SneakScope                   IncSearch
-  " v-- For all matches except the first, where the cursor currently resides
-hi! link SneakLabel                   Search
+" Sneak
+hi! link Sneak Visual
+hi! link SneakLabel Search
+hi! link SneakScope IncSearch
 
-"======== dirvish ===========
-hi   DirvishPathTail          guifg=NONE    guibg=NONE   guisp=NONE    gui=bold     ctermfg=NONE  ctermbg=NONE  cterm=bold
-hi! link DirvishArg                   Search
+" Dirvish
+hi! link DirvishArg Search
+hi DirvishPathTail guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bold
 
-"======== nvim-hlslens ======
-hi! link HlSearchLensNear StatusLine
+" HL Search Lens
 hi! link HlSearchLens StatusLineNC
+hi! link HlSearchLensNear StatusLine
 hi! link HlSearchNear Search
 
-"======== lightline =========
-let lightline_enabled = get(g:, 'yui_lightline', v:false)
-if lightline_enabled == v:true
-  let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
-  let s:p.normal.left = [
-        \['#e8ffd1', '#408000', 241, 254],
-        \['#efeae5', '#7f726c', 241, 254]
-        \]
-  let s:p.normal.right = [
-        \['#efeae5', '#635954', 241, 254],
-        \['#efeae5', '#7f726c', 241, 254],
-        \['#292523', '#b4aba7', 245, 236]
-        \]
-  let s:p.normal.middle = [
-        \[ '#635954', '#b4aba7', 245, 236]
-        \]
-  let s:p.insert.left =  [ 
-        \['#d8ebf8', '#165079', 195, 25],
-        \['#efeae5', '#7f726c', 241, 254]
-        \]
-  let s:p.visual.left = [
-        \['#DCD7F9', '#5137e1', 124, 231],
-        \['#efeae5', '#7f726c', 241, 254]
-        \]
-  let s:p.replace.left = [
-        \['#ffffff', '#e44c22', 57, 231],
-        \['#efeae5', '#7f726c', 241, 254]
-        \]
-  let s:p.normal.error = [
-        \['#fce3e5', '#a7111d', 224, 124]
-        \]
-  let s:p.normal.warning = [
-        \['#f9ffa3', '#7c8500', 229, 94]
-        \]
-  let s:p.inactive.right = [
-        \['#7f726c', '#cfbfb0', 233, 235],
-        \['#7f726c', '#cfbfb0', 233, 235],
-        \['#7f726c', '#cfbfb0', 233, 235]
-        \]
-  let s:p.inactive.left = s:p.inactive.right[1:]
-  let s:p.inactive.middle = [
-        \['#7f726c', '#dcd1c6', 233, 235]
-        \]
-  let s:p.tabline.left = s:p.inactive.middle
-  let s:p.tabline.tabsel = s:p.normal.left[1:]
-  let s:p.tabline.middle = [
-        \['#635954', '#efeae5', 254, 241]
-        \]
-  let s:p.tabline.right = s:p.normal.left[1:]
+" Conflict Marker
+hi! link ConflictMarkerBegin DiffAdd
+hi! link ConflictMarkerEnd DiffText
+hi! link ConflictMarkerOurs DiffAdd
+hi! link ConflictMarkerTheirs DiffText
 
-  let g:lightline#colorscheme#yui#palette = s:p
+" Treesitter Context
+hi! link TreesitterContext Pmenu
+hi TreesitterContextBottom gui=underline cterm=underline
+
+" Which Key
+hi! link WhichKeyFloating Pmenu
+hi WhichKeySeperator guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+
+" Leap
+hi LeapLabelPrimary guifg=#ffffff ctermfg=231 guibg=#ed3f1c ctermbg=202 gui=bold cterm=bold
+hi LeapLabelSecondary guifg=#fef0e8 ctermfg=255 guibg=#7c4f18 ctermbg=94 gui=none cterm=none
+hi LeapLabelSelected guifg=#350303 ctermfg=233 guibg=#f8acac ctermbg=217 gui=none cterm=none
+hi LeapMatch guifg=#4a5054 ctermfg=239 guibg=#d9e0e3 ctermbg=253 gui=none cterm=none
+
+" yui_folds
+let s:yui_folds_value = get(g:, 'yui_folds', 'fade')
+if s:yui_folds_value ==? 'fade'
+	hi FoldColumn guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
+	hi Folded guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
+elseif s:yui_folds_value ==? 'emphasize'
+	hi FoldColumn guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
+	hi Folded guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
 endif
 
-"== conflict-marker.vim =====
-hi! link ConflictMarkerBegin DiffAdd
-hi! link ConflictMarkerOurs DiffAdd
-" hi! link ConflictMarkerCommonAncestors
-" ConflictMarkerCommonAncestors |||||||
-" ConflictMarkerCommonAncestorsHunk actual diff content
-" ConflictMarkerSeparator ========
-hi! link ConflictMarkerTheirs DiffText
-hi! link ConflictMarkerEnd DiffText
+" yui_line_numbers
+let s:yui_line_numbers_value = get(g:, 'yui_line_numbers', 'fade')
+if s:yui_line_numbers_value ==? 'fade'
+	hi SignColumn guifg=fg ctermfg=fg guibg=bg ctermbg=bg
+	hi LineNr guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
+elseif s:yui_line_numbers_value ==? 'emphasize'
+	hi SignColumn guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
+	hi LineNr guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
+endif
 
-"==== treesitter-context ====
-" The foreground colors are taken from actual Treesitter highlight groups. You
-" can only set the background color. On the other hand, setting guifg on the
-" TreesitterContextBottom group also seems to affect some of the other color?
-" It's unclear to me how this is supposed to work.
-hi TreesitterContextBottom gui=underline
-hi! link TreesitterContext Pmenu
+" yui_emphasized_comments
+let s:yui_emphasized_comments_value = get(g:, 'yui_emphasized_comments', 0)
+if s:yui_emphasized_comments_value ==? 1
+	hi Comment guifg=#ed3f1c ctermfg=202 guibg=NONE ctermbg=NONE gui=italic cterm=italic
+elseif s:yui_emphasized_comments_value ==? 0
+	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
+endif
 
-"==== which-key =============
-hi       WhichKeySeperator guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE guisp=NONE gui=NONE cterm=NONE
-hi! link WhichKeyFloating  Pmenu
+" yui_comments
+let s:yui_comments_value = get(g:, 'yui_comments', 'normal')
+if s:yui_comments_value ==? 'normal'
+	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
+elseif s:yui_comments_value ==? 'fade'
+	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
+elseif s:yui_comments_value ==? 'emphasize'
+	hi Comment guifg=#ed3f1c ctermfg=202 guibg=NONE ctermbg=NONE gui=italic cterm=italic
+elseif s:yui_comments_value ==? 'bg'
+	hi Comment guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254 gui=NONE cterm=NONE
+endif
+
+" yui_lightline
+let s:yui_lightline_value = get(g:, 'yui_lightline', v:false)
+if s:yui_lightline_value ==? v:true
+	let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+	let s:p.visual.left = [
+		\['#dcd7f9', '#6132d7', 189, 62],
+		\['#f6f3f0', '#72604b', 255, 59],
+		\]
+	let s:p.tabline.tabsel = [
+		\['#f6f3f0', '#72604b', 255, 59],
+		\]
+	let s:p.tabline.middle = [
+		\['#5f503e', '#f6f3f0', 239, 255],
+		\]
+	let s:p.tabline.left = [
+		\['#72604b', '#e0d5ca', 59, 188],
+		\]
+	let s:p.replace.left = [
+		\['#fdfcfb', '#ed3f1c', 231, 202],
+		\['#f6f3f0', '#72604b', 255, 59],
+		\]
+	let s:p.normal.error = [
+		\['#350303', '#f8acac', 233, 217],
+		\]
+	let s:p.normal.warning = [
+		\['#fef0e8', '#7c4f18', 255, 94],
+		\]
+	let s:p.normal.middle = [
+		\['#5f503e', '#867159', 239, 95],
+		\]
+	let s:p.normal.left = [
+		\['#e2dba3', '#4e4b36', 187, 238],
+		\['#f6f3f0', '#72604b', 255, 59],
+		\]
+	let s:p.normal.right = [
+		\['#f6f3f0', '#5f503e', 255, 239],
+		\['#f6f3f0', '#72604b', 255, 59],
+		\['#453a2c', '#867159', 237, 95],
+		\]
+	let s:p.insert.left = [
+		\['#d9e0e3', '#4a5054', 253, 239],
+		\['#f6f3f0', '#72604b', 255, 59],
+		\]
+	let s:p.inactive.middle = [
+		\['#72604b', '#e0d5ca', 59, 188],
+		\]
+	let s:p.inactive.left = [
+		\['#72604b', '#d6c7b6', 59, 187],
+		\['#72604b', '#d6c7b6', 59, 187],
+		\]
+	let s:p.inactive.right = [
+		\['#72604b', '#d6c7b6', 59, 187],
+		\['#72604b', '#d6c7b6', 59, 187],
+		\['#72604b', '#d6c7b6', 59, 187],
+		\]
+	let g:lightline#colorscheme#yui#palette = s:p
+endif
+

--- a/doc/yui.txt
+++ b/doc/yui.txt
@@ -1,63 +1,76 @@
+*yui.txt*                             A minimal colorscheme for Vim and Neovim
 
 YUI | ユイ
 
-===========================================================================
-Yui options                                     *yui-options*
+==============================================================================
+OPTIONS                                                          *yui-options*
 
-                                                *g:yui_lightline*
+                                                                 *g:yui_folds*
 
-Default: v:false
+g:yui_folds~
 
-- v:true: register the "yui" lightline color palette. You still need to
-  set the lightline colorscheme to "yui" as well.
+How folds should be displayed
+* 'emphasize':                                        Make folds more visible
+* 'fade':                                            Fade out folds (default)
 
->
+Example: >
+  let g:yui_folds = 'fade'
+<
+
+------------------------------------------------------------------------------
+                                                          *g:yui_line_numbers*
+
+g:yui_line_numbers~
+
+How line numbers should be displayed
+* 'emphasize':                                 Make line numbers more visible
+* 'fade':                                     Fade out line numbers (default)
+
+Example: >
+  let g:yui_line_numbers = 'fade'
+<
+
+------------------------------------------------------------------------------
+                                                   *g:yui_emphasized_comments*
+
+g:yui_emphasized_comments~
+
+DEPRECATED: Use |yui_comments| instead
+
+Whether to emphasize comments
+* 0:                                                Do not emphasize comments
+* 1:                                                       Emphasize comments
+
+Example: >
+  let g:yui_emphasized_comments = 0
+<
+
+------------------------------------------------------------------------------
+                                                              *g:yui_comments*
+
+g:yui_comments~
+
+How comments should be displayed
+* 'bg':                                 Make comments have a background color
+* 'emphasize':                                             Emphasize comments
+* 'fade':                                                   Fade out comments
+* 'normal':                               Do not emphasize comments (default)
+
+Example: >
+  let g:yui_comments = 'normal'
+<
+
+------------------------------------------------------------------------------
+                                                             *g:yui_lightline*
+
+g:yui_lightline~
+
+Whether to use the lightline theme
+* v:true:                                             Use the lightline theme
+
+Example: >
   let g:yui_lightline = v:true
   let g:lightline.colorscheme = 'yui'
 <
 
-                                                *g:yui_emphasized_comments*
-
-Deprecated: Please use |g:yui_comments| instead.
-
-Set to 1 if you want comments to be emphasized by making them orange. 
-
->
-  let g:yui_emphasized_comments = 0
-<
-
-                                                *g:yui_comments*
-
-- 'emphasize': orange text
-- 'fade': text less visible
-- 'bg': text non-italic but different background
-- 'normal': Default. Italic text, same color as Normal text
-
-g:yui_emphasized_comments takes precedence to preserve backwards compatibility.
-
->
-  let g:yui_comments = 'emphasize'
-<
-
-                                                *g:yui_folds*
-
-Default: "fade"
-
-- 'emphasize': more visible background and foreground color combination
-- 'fade': text less visible
-
->
-  let g:yui_folds = 'emphasize'
-<
-
-                                                *g:yui_line_numbers*
-
-Default: "fade"
-
-Set to 'emphasize' if you want line numbers and signcolumn to be emphasized by
-giving it a more visible background and foreground color combination. Set to
-'fade' to make folded text less visible.
-
->
-  let g:yui_line_numbers = 'emphasize'
-<
+ vim:tw=78:et:ft=help:norl:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678500213,
+        "narHash": "sha256-A5s2rXawJ+dCThkMXoMuYW8dgyUmkElcyfVJUot/Vr0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2ce9b9842b5e63884dfc3dea6689769e2a1ea309",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "A minimalistic Vim and Neovim color scheme that uses very few colors.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        yuiVim = pkgs.vimUtils.buildVimPlugin rec {
+          name = "yui";
+
+          buildInputs = with pkgs; [
+            lua54Packages.lua
+          ];
+
+          buildPhase = ''
+            make
+            rm -r template Makefile flake.nix flake.lock README.md
+          '';
+
+          src = pkgs.lib.cleanSourceWith {
+            # Remove files that have the infix "screenshots" in their path and
+            # remove the folders "colors" and "doc"
+            filter = path: type:
+              !(pkgs.lib.hasInfix "screenshots" path)
+              && !(pkgs.lib.hasInfix "colors/" path)
+              && !(pkgs.lib.hasInfix "doc/" path);
+            src = ./.;
+          };
+        };
+      in rec {
+        packages = flake-utils.lib.flattenTree {
+          yui = yuiVim;
+        };
+
+        defaultPackage = packages.yui;
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            coreutils
+            moreutils
+            jq
+            alejandra
+            lua54Packages.lua
+            lua-language-server
+            stylua
+          ];
+        };
+      }
+    );
+}

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/s2g960dyp805rx9fd9gh4lb3ryhci9bn-vimplugin-yui

--- a/template/colour.lua
+++ b/template/colour.lua
@@ -1,0 +1,74 @@
+-- This file is a port of https://raw.githubusercontent.com/tmux/tmux/master/colour.c
+-- Also see the PR adding this functionality: https://github.com/tmux/tmux/pull/432
+
+local M = {}
+
+local function colour_dist_sq(R, G, B, r, g, b)
+	return (R - r) * (R - r) + (G - g) * (G - g) + (B - b) * (B - b)
+end
+
+local function colour_to_6cube(v)
+	if v < 48 then
+		return 0
+	elseif v < 114 then
+		return 1
+	end
+	return (v - 35) // 40
+end
+
+-- Convert an RGB triplet to the xterm(1) 256 colour palette.
+--
+-- xterm provides a 6x6x6 colour cube (16 - 231) and 24 greys (232 - 255). We
+-- map our RGB colour to the closest in the cube, also work out the closest
+-- grey, and use the nearest of the two.
+--
+-- Note that the xterm has much lower resolution for darker colours (they are
+-- not evenly spread out), so our 6 levels are not evenly spread: 0x0, 0x5f
+-- (95), 0x87 (135), 0xaf (175), 0xd7 (215) and 0xff (255). Greys are more
+-- evenly spread (8, 18, 28 ... 238).
+M.color_find_256 = function(r, g, b)
+	-- The colors which are represented are all the R/G/B combination where each
+	-- channel is one of 6 possible values:
+	-- 0x0, 0x5f (95), 0x87 (135), 0xaf (175), 0xd7 (215) and 0xff (255).
+	local q2c = { 0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff }
+
+	-- Map RGB to 6x6x6 cube.
+	local ir, ig, ib = colour_to_6cube(r), colour_to_6cube(g), colour_to_6cube(b)
+	local cr, cg, cb = q2c[ir + 1], q2c[ig + 1], q2c[ib + 1]
+
+	-- If we have hit the colour exactly, return early.
+	if cr == r and cg == g and cb == b then
+		return 16 + (36 * ir) + (6 * ig) + ib
+	end
+
+	-- Work out the closest grey (average of RGB).
+	local grey_avg = (r + g + b) // 3
+	local grey_idx, grey
+	if grey_avg > 238 then
+		grey_idx = 23
+	else
+		grey_idx = (grey_avg - 3) // 10
+	end
+	grey = 8 + (10 * grey_idx)
+
+	-- Is grey or 6x6x6 colour closest?
+	local d = colour_dist_sq(cr, cg, cb, r, g, b)
+	local idx
+	if colour_dist_sq(grey, grey, grey, r, g, b) < d then
+		idx = 232 + grey_idx
+	else
+		idx = 16 + (36 * ir) + (6 * ig) + ib
+	end
+	return idx
+end
+
+M.hex_to_rgb = function(hex)
+	hex = hex:gsub("#", "")
+	return tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)), tonumber("0x" .. hex:sub(5, 6))
+end
+
+M.hex_to_256 = function(hex)
+	return M.color_find_256(M.hex_to_rgb(hex))
+end
+
+return M

--- a/template/gen_docs.lua
+++ b/template/gen_docs.lua
@@ -1,0 +1,3 @@
+local theme = require("theme")
+local yui = require("yui")
+print(theme.make_docs(yui.option_groups))

--- a/template/gen_theme.lua
+++ b/template/gen_theme.lua
@@ -1,0 +1,3 @@
+local yui = require("yui")
+local theme = require("theme")
+print(theme.make_theme(yui.term_colors, yui.option_groups, yui.groups))

--- a/template/hsluv.lua
+++ b/template/hsluv.lua
@@ -1,0 +1,347 @@
+--[[
+Lua implementation of HSLuv and HPLuv color spaces
+Homepage: http://www.hsluv.org/
+
+Copyright (C) 2019 Alexei Boronine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+local hsluv = {}
+
+local hexChars = "0123456789abcdef"
+
+
+local distance_line_from_origin = function(line)
+    return math.abs(line.intercept) / math.sqrt((line.slope ^ 2) + 1)
+end
+
+local length_of_ray_until_intersect = function(theta, line)
+    return line.intercept / (math.sin(theta) - line.slope * math.cos(theta))
+end
+
+hsluv.get_bounds = function(l)
+    local result = {};
+    local sub2;
+    local sub1 = ((l + 16) ^ 3) / 1560896;
+    if sub1 > hsluv.epsilon then
+        sub2 = sub1;
+    else
+        sub2 = l / hsluv.kappa;
+    end
+
+    for i = 1, 3 do
+        local m1 = hsluv.m[i][1];
+        local m2 = hsluv.m[i][2];
+        local m3 = hsluv.m[i][3];
+
+        for t = 0, 1 do
+            local top1 = (284517 * m1 - 94839 * m3) * sub2;
+            local top2 = (838422 * m3 + 769860 * m2 + 731718 * m1) * l * sub2 - 769860 * t * l;
+            local bottom = (632260 * m3 - 126452 * m2) * sub2 + 126452 * t;
+            table.insert(result, {
+                slope = top1 / bottom,
+                intercept = top2 / bottom
+            })
+        end;
+    end;
+    return result
+end
+
+hsluv.max_safe_chroma_for_l = function(l)
+    local bounds = hsluv.get_bounds(l);
+    local min = 1.7976931348623157e+308;
+
+    for i = 1, 6 do
+        local length = distance_line_from_origin(bounds[i]);
+        if length >= 0 then
+            min = math.min(min, length);
+        end;
+    end;
+    return min;
+end
+
+hsluv.max_safe_chroma_for_lh = function(l, h)
+    local hrad = h / 360 * math.pi * 2;
+    local bounds = hsluv.get_bounds(l);
+    local min = 1.7976931348623157e+308;
+
+    for i = 1, 6 do
+        local bound = bounds[i];
+        local length = length_of_ray_until_intersect(hrad, bound);
+        if length >= 0 then
+            min = math.min(min, length);
+        end;
+    end;
+    return min
+end
+
+hsluv.dot_product = function(a, b)
+    local sum = 0;
+    for i = 1, 3 do
+        sum = sum + a[i] * b[i];
+    end;
+    return sum
+end
+
+hsluv.from_linear = function(c)
+    if c <= 0.0031308 then
+        return 12.92 * c
+    else
+        return 1.055 * (c ^ 0.416666666666666685) - 0.055
+    end;
+end
+
+hsluv.to_linear = function(c)
+    if c > 0.04045 then
+        return ((c + 0.055) / 1.055) ^ 2.4
+    else
+        return c / 12.92
+    end;
+end
+
+hsluv.xyz_to_rgb = function(tuple)
+    return {
+        hsluv.from_linear(hsluv.dot_product(hsluv.m[1], tuple)),
+        hsluv.from_linear(hsluv.dot_product(hsluv.m[2], tuple)),
+        hsluv.from_linear(hsluv.dot_product(hsluv.m[3], tuple))
+    }
+end
+
+hsluv.rgb_to_xyz = function(tuple)
+    local rgbl = {
+        hsluv.to_linear(tuple[1]),
+        hsluv.to_linear(tuple[2]),
+        hsluv.to_linear(tuple[3])
+    };
+    return {
+        hsluv.dot_product(hsluv.minv[1], rgbl),
+        hsluv.dot_product(hsluv.minv[2], rgbl),
+        hsluv.dot_product(hsluv.minv[3], rgbl)
+    }
+end
+
+hsluv.y_to_l = function(Y)
+    if Y <= hsluv.epsilon then
+        return Y / hsluv.refY * hsluv.kappa
+    else
+        return 116 * ((Y / hsluv.refY) ^ 0.333333333333333315) - 16
+    end;
+end
+
+hsluv.l_to_y = function(L)
+    if L <= 8 then
+        return hsluv.refY * L / hsluv.kappa
+    else
+        return hsluv.refY * (((L + 16) / 116) ^ 3)
+    end;
+end
+
+hsluv.xyz_to_luv = function(tuple)
+    local X = tuple[1];
+    local Y = tuple[2];
+    local divider = X + 15 * Y + 3 * tuple[3];
+    local varU = 4 * X;
+    local varV = 9 * Y;
+    if divider ~= 0 then
+        varU = varU / divider;
+        varV = varV / divider;
+    else
+        varU = 0;
+        varV = 0;
+    end
+    local L = hsluv.y_to_l(Y);
+    if L == 0 then
+        return { 0, 0, 0 }
+    end;
+    return { L, 13 * L * (varU - hsluv.refU), 13 * L * (varV - hsluv.refV) }
+end
+
+hsluv.luv_to_xyz = function(tuple)
+    local L = tuple[1];
+    local U = tuple[2];
+    local V = tuple[3];
+    if L == 0 then
+        return { 0, 0, 0 }
+    end;
+    local varU = U / (13 * L) + hsluv.refU;
+    local varV = V / (13 * L) + hsluv.refV;
+    local Y = hsluv.l_to_y(L);
+    local X = 0 - (9 * Y * varU) / ((((varU - 4) * varV) - varU * varV));
+    return { X, Y, (9 * Y - 15 * varV * Y - varV * X) / (3 * varV) }
+end
+
+hsluv.luv_to_lch = function(tuple)
+    local L = tuple[1];
+    local U = tuple[2];
+    local V = tuple[3];
+    local C = math.sqrt(U * U + V * V);
+    local H
+    if C < 0.00000001 then
+        H = 0;
+    else
+        H = math.atan(V, U) * 180.0 / 3.1415926535897932;
+        if H < 0 then
+            H = 360 + H;
+        end;
+    end;
+    return { L, C, H }
+end
+
+hsluv.lch_to_luv = function(tuple)
+    local L = tuple[1];
+    local C = tuple[2];
+    local Hrad = tuple[3] / 360.0 * 2 * math.pi;
+    return { L, math.cos(Hrad) * C, math.sin(Hrad) * C };
+end
+
+hsluv.hsluv_to_lch = function(tuple)
+    local H = tuple[1];
+    local S = tuple[2];
+    local L = tuple[3];
+    if L > 99.9999999 then
+        return { 100, 0, H }
+    end;
+    if L < 0.00000001 then
+        return { 0, 0, H }
+    end;
+    return { L, hsluv.max_safe_chroma_for_lh(L, H) / 100 * S, H }
+end
+
+hsluv.lch_to_hsluv = function(tuple)
+    local L = tuple[1];
+    local C = tuple[2];
+    local H = tuple[3];
+    local max_chroma = hsluv.max_safe_chroma_for_lh(L, H)
+    if L > 99.9999999 then
+        return { H, 0, 100 }
+    end;
+    if L < 0.00000001 then
+        return { H, 0, 0 }
+    end;
+
+    return { H, C / max_chroma * 100, L }
+end
+
+hsluv.hpluv_to_lch = function(tuple)
+    local H = tuple[1];
+    local S = tuple[2];
+    local L = tuple[3];
+    if L > 99.9999999 then
+        return { 100, 0, H }
+    end;
+    if L < 0.00000001 then
+        return { 0, 0, H }
+    end;
+    return { L, hsluv.max_safe_chroma_for_l(L) / 100 * S, H }
+end
+
+hsluv.lch_to_hpluv = function(tuple)
+    local L = tuple[1];
+    local C = tuple[2];
+    local H = tuple[3];
+    if L > 99.9999999 then
+        return { H, 0, 100 }
+    end;
+    if L < 0.00000001 then
+        return { H, 0, 0 }
+    end;
+    return { H, C / hsluv.max_safe_chroma_for_l(L) * 100, L }
+end
+
+hsluv.rgb_to_hex = function(tuple)
+    local h = "#";
+    for i = 1, 3 do
+        local c = math.floor(tuple[i] * 255 + 0.5);
+        local digit2 = math.fmod(c, 16);
+        local x = (c - digit2) / 16;
+        local digit1 = math.floor(x);
+        h = h .. string.sub(hexChars, digit1 + 1, digit1 + 1)
+        h = h .. string.sub(hexChars, digit2 + 1, digit2 + 1)
+    end;
+    return h
+end
+
+hsluv.hex_to_rgb = function(hex)
+    hex = string.lower(hex)
+    local ret = {}
+    for i = 0, 2 do
+        local char1 = string.sub(hex, i * 2 + 2, i * 2 + 2);
+        local char2 = string.sub(hex, i * 2 + 3, i * 2 + 3);
+        local digit1 = string.find(hexChars, char1) - 1
+        local digit2 = string.find(hexChars, char2) - 1
+        ret[i + 1] = (digit1 * 16 + digit2) / 255.0;
+    end;
+    return ret
+end
+
+hsluv.lch_to_rgb = function(tuple)
+    return hsluv.xyz_to_rgb(hsluv.luv_to_xyz(hsluv.lch_to_luv(tuple)))
+end
+
+hsluv.rgb_to_lch = function(tuple)
+    return hsluv.luv_to_lch(hsluv.xyz_to_luv(hsluv.rgb_to_xyz(tuple)))
+end
+
+hsluv.hsluv_to_rgb = function(tuple)
+    return hsluv.lch_to_rgb(hsluv.hsluv_to_lch(tuple))
+end
+
+hsluv.rgb_to_hsluv = function(tuple)
+    return hsluv.lch_to_hsluv(hsluv.rgb_to_lch(tuple))
+end
+
+hsluv.hpluv_to_rgb = function(tuple)
+    return hsluv.lch_to_rgb(hsluv.hpluv_to_lch(tuple))
+end
+
+hsluv.rgb_to_hpluv = function(tuple)
+    return hsluv.lch_to_hpluv(hsluv.rgb_to_lch(tuple))
+end
+
+hsluv.hsluv_to_hex = function(tuple)
+    return hsluv.rgb_to_hex(hsluv.hsluv_to_rgb(tuple))
+end
+
+hsluv.hpluv_to_hex = function(tuple)
+    return hsluv.rgb_to_hex(hsluv.hpluv_to_rgb(tuple))
+end
+
+hsluv.hex_to_hsluv = function(s)
+    return hsluv.rgb_to_hsluv(hsluv.hex_to_rgb(s))
+end
+
+hsluv.hex_to_hpluv = function(s)
+    return hsluv.rgb_to_hpluv(hsluv.hex_to_rgb(s))
+end
+
+hsluv.m = {
+    { 3.240969941904521, -1.537383177570093, -0.498610760293 },
+    { -0.96924363628087, 1.87596750150772, 0.041555057407175 },
+    { 0.055630079696993, -0.20397695888897, 1.056971514242878 }
+}
+hsluv.minv = {
+    { 0.41239079926595, 0.35758433938387, 0.18048078840183 },
+    { 0.21263900587151, 0.71516867876775, 0.072192315360733 },
+    { 0.019330818715591, 0.11919477979462, 0.95053215224966 }
+}
+hsluv.refY = 1.0
+hsluv.refU = 0.19783000664283
+hsluv.refV = 0.46831999493879
+hsluv.kappa = 903.2962962
+hsluv.epsilon = 0.0088564516
+
+return hsluv

--- a/template/theme.lua
+++ b/template/theme.lua
@@ -1,0 +1,511 @@
+local M = {}
+
+local colour = require("colour")
+
+-- special colors that can be used for guifg and guibg
+local special_colors = {
+	fg = true,
+	bg = true,
+	foreground = true,
+	background = true,
+	NONE = true,
+	none = true,
+}
+
+-- allowed values for gui
+local underlines = {
+	undercurl = true,
+	underline = true,
+	underdouble = true,
+	underdotted = true,
+	underdashed = true,
+}
+
+-- allowed attributes for gui and cterm
+local allowed_attrs = {
+	bold = true,
+	underline = true,
+	undercurl = true,
+	underdouble = true,
+	underdotted = true,
+	underdashed = true,
+	inverse = true,
+	reverse = true,
+	standout = true,
+	italic = true,
+	strikethrough = true,
+	nocombine = true,
+	NONE = true,
+}
+
+-- This is a helper function to make a highlight group. It takes a table with the following keys:
+--
+--   name: the name of the highlight group
+--   guifg: the foreground color
+--   guibg: the background color
+--   gui: the gui and cterm style of the highlight group (e.g. "bold"), can be a string or a list
+--   cterm: the cterm style of the highlight group (e.g. "bold"), can be a string or a list.
+--          If this is not specified, then it will be set to the same value as gui.
+--   link: the name of the highlight group to link to
+--   guisp: the special color to use for underlines
+--
+-- * If link is specified, then the other keys are ignored.
+-- * If guisp is specified, then gui must be one of "underline", "undercurl", "underdouble",
+--   "underdotted", or "underdashed".
+-- * If guifg or guibg is "fg"/"foreground" or "bg"/"background", then the corresponding color will
+--   be set to the foreground or background color of the theme.
+-- * If guifg or guibg is "NONE" or "none", then the corresponding color will be set to "NONE".
+--
+-- The function will return a string that can be used in a vimscript file to define the highlight
+-- group.
+M.make_hi = function(g)
+	local buf = {}
+
+	if g.link then
+		table.insert(buf, string.format("hi! link %s %s", g.name, g.link))
+
+		for _, s in ipairs({ "guibg", "guifg", "gui", "guisp", "cterm" }) do
+			assert(g[s] == nil, s .. " must be nil for link but was " .. tostring(g[s]))
+		end
+		goto done
+	end
+
+	table.insert(buf, "hi " .. g.name)
+
+	if g.guifg then
+		if special_colors[g.guifg] then
+			table.insert(buf, string.format("guifg=%s ctermfg=%s", g.guifg, g.guifg))
+		else
+			table.insert(buf, string.format("guifg=%s ctermfg=%d", g.guifg, colour.hex_to_256(g.guifg)))
+		end
+	end
+
+	if g.guibg then
+		if special_colors[g.guibg] then
+			table.insert(buf, string.format("guibg=%s ctermbg=%s", g.guibg, g.guibg))
+		else
+			table.insert(buf, string.format("guibg=%s ctermbg=%d", g.guibg, colour.hex_to_256(g.guibg)))
+		end
+	end
+
+	if g.guisp then
+		assert(underlines[g.gui], "guisp can only be used with gui=underline")
+		table.insert(buf, "guisp=" .. g.guisp)
+	end
+
+	if g.gui then
+		if type(g.gui) == "string" then
+			table.insert(buf, "gui=" .. g.gui)
+
+			if not g.cterm then
+				table.insert(buf, "cterm=" .. g.gui)
+			end
+		else
+			local attrs = {}
+			for _, attr in ipairs(g.gui) do
+				assert(allowed_attrs[attr], "invalid gui attribute: " .. attr)
+				table.insert(attrs, attr)
+			end
+			table.insert(buf, "gui=" .. table.concat(attrs, ","))
+
+			if not g.cterm then
+				table.insert(buf, "cterm=" .. table.concat(attrs, ","))
+			end
+		end
+	end
+
+	if g.cterm then
+		if type(g.cterm) == "string" then
+			table.insert(buf, "cterm=" .. g.cterm)
+		else
+			local attrs = {}
+			for _, attr in ipairs(g.cterm) do
+				assert(allowed_attrs[attr], "invalid cterm attribute: " .. attr)
+				table.insert(attrs, attr)
+			end
+			table.insert(buf, "cterm=" .. table.concat(attrs, ","))
+		end
+	end
+
+	::done::
+	return table.concat(buf, " ")
+end
+
+-- let s:yui_lightline_value = get(g:, 'yui_lightline', v:false)
+-- if yui_lightline_value ==? v:true
+
+-- This is a helper function to make a highlight group blocks whose value is determined by a global
+-- variable. It takes a table with the following keys:
+--
+--  name: the name of the global variable
+--  default: the default value of the global variable
+--  description: a description of what this option does. This will be used in the documentation.
+--  cases: a table mapping values of the global variable to highlight groups and a description of
+--         what this option value does
+--  cases[rhs].description: a description of what this option value does, this will be used in the
+--                          documentation
+--  cases[rhs].groups: a table of highlight groups
+--
+--  Each value in groups can be a string or a table that can be passed to make_hi.
+--  If the global variable is not equal to any of the keys in cases, then no highlight groups will
+--  be defined.
+--
+--  The function will return a string that can be used in a vimscript file to define the highlight
+--  groups.
+--
+--  The highlight groups will be defined in the following way:
+--  let s:${name}_value = get(g:, '${name}', default)
+--  if s:${name}_value ==? rhs1
+--    hl_group1
+--    hl_group2
+--    ...
+--  elseif s:${name}_value ==? rhs2
+--    hl_group1
+--    hl_group2
+--    ...
+--    ...
+--  endif
+--
+--  The keys in cases will be sorted in descending order, so that the longest keys are checked first.
+--  This is done to avoid Git diffs due to random key order when iterating over a table.
+--
+--  For example:
+--
+--  M.make_opt_hi {
+--    name = "yui_lightline",
+--    default = v:false,
+--    description = "Whether to use the Yui lightline theme",
+--    cases = {
+--      v:true = {
+--        groups = { name = "YuiLightline", guifg = "#ffffff", guibg = "#000000" }
+--        description = "Use the Yui lightline theme"
+--      },
+--      v:false = {
+--        groups = { name = "YuiLightlineInactive", guifg = "#ffffff", guibg = "#000000" }
+--        description = "Use the Yui lightline theme"
+--      },
+--    },
+--  }
+--
+--  will return:
+--
+--  let s:yui_lightline_value = get(g:, 'yui_lightline', v:false)
+--  if s:yui_lightline_value ==? v:true
+--    hi YuiLightline guifg=#ffffff guibg=#000000
+--  elseif s:yui_lightline_value ==? v:false
+--    hi YuiLightlineInactive guifg=#ffffff guibg=#000000
+--  endif
+M.make_opt_hi = function(opt)
+	local var_name_vim = opt.name .. "_value"
+	local lines = {
+		string.format("let s:%s = get(g:, '%s', %s)", var_name_vim, opt.name, opt.default),
+	}
+
+	-- We want to iterate over keys in a table in a predictable and stable order
+	local right_hand_if_sorted = {}
+	for p in pairs(opt.cases) do
+		table.insert(right_hand_if_sorted, p)
+	end
+	table.sort(right_hand_if_sorted, function(a, b)
+		return a > b
+	end)
+
+	local is_first = true
+	for _, rhs in ipairs(right_hand_if_sorted) do
+		local groups = opt.cases[rhs].groups
+		local line = is_first and string.format("if s:%s ==? %s", var_name_vim, rhs)
+			or string.format("elseif s:%s ==? %s", var_name_vim, rhs)
+
+		table.insert(lines, line)
+
+		for _, hl_group in ipairs(groups) do
+			if type(hl_group) == "string" then
+				-- Split the string into multiple lines and indent each line by a tab,
+				-- so the generated vimscript file is more readable
+				for l in hl_group:gmatch("[^\n]+") do
+					table.insert(lines, "\t" .. l)
+				end
+			else
+				table.insert(lines, "\t" .. M.make_hi(hl_group))
+			end
+		end
+
+		is_first = false
+	end
+
+	table.insert(lines, "endif")
+
+	return table.concat(lines, "\n")
+end
+
+-- make_term takes a table of 16 colors and returns a string that can be used in a vimscript file
+-- to define the terminal colors. The colors should be in the format #RRGGBB.
+--
+-- The returned string will be in the following format:
+--
+-- if has('nvim')
+--  let g:terminal_color_0 = '#RRGGBB'
+--  ...
+-- else
+-- let g:terminal_ansi_colors = [
+--   \'#RRGGBB',
+--   ...]
+-- endif
+M.make_term = function(term_colors)
+	local nvim, vim = {}, {}
+	for i, color in ipairs(term_colors) do
+		table.insert(nvim, string.format("\tlet g:terminal_color_%d = '%s'", i - 1, color))
+		local is_last = i == #term_colors
+		table.insert(vim, string.format("\t\\'%s'%s", color, (is_last and "]" or ",")))
+	end
+
+	local s = string.format(
+		[[
+if has('nvim')
+%s
+else
+  let g:terminal_ansi_colors = [
+%s
+endif
+  ]],
+		table.concat(nvim, "\n"),
+		table.concat(vim, "\n")
+	)
+
+	return s
+end
+
+-- make_lightline takes a table of key/value pairs and returns a table of strings that can be used
+-- in a vimscript file to define the lightline colors.
+-- The keys in the table should be in the format {mode}.{name}, where mode is the lightline mode
+-- (e.g. normal, insert, visual) and name is the lightline component (e.g. left, right, error).
+-- The value should be a table of tables, where each inner table contains the foreground color,
+-- background color, and style (optional).
+M.make_lightline = function(config)
+	local lightline_lines = {}
+
+	-- We want to iterate over keys in a table in a predictable and stable order
+	-- to avoid Git diffs due to random key order when iterating over a table.
+	local config_keys = {}
+	for k in pairs(config) do
+		table.insert(config_keys, k)
+	end
+
+	table.sort(config_keys, function(a, b)
+		return a > b
+	end)
+
+	for _, mode in ipairs(config_keys) do
+		local part = config[mode]
+		for name, lightline_groups in pairs(part) do
+			table.insert(lightline_lines, string.format("let s:p.%s.%s = [", mode, name))
+
+			for _, colors in ipairs(lightline_groups) do
+				local fg, bg, style = table.unpack(colors)
+				local fg_code, bg_code = colour.hex_to_256(fg), colour.hex_to_256(bg)
+
+				local line
+				if style ~= nil then
+					line = string.format("\t\\['%s', '%s', %d, %d, '%s'],", fg, bg, fg_code, bg_code, style)
+				else
+					line = string.format("\t\\['%s', '%s', %d, %d],", fg, bg, fg_code, bg_code)
+				end
+
+				table.insert(lightline_lines, line)
+			end
+
+			table.insert(lightline_lines, "\t\\]")
+		end
+	end
+
+	local out = {
+		"let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}",
+	}
+
+	for _, line in ipairs(lightline_lines) do
+		table.insert(out, line)
+	end
+
+	table.insert(out, "let g:lightline#colorscheme#yui#palette = s:p")
+
+	return out
+end
+
+-- make_theme takes as arguments a list of terminal colors, option groups and blocks of highlight
+-- groups. A block is table where the first value is the name of the block, and all subsequent
+-- values are tables that can be passed to either make_hi or make_opt_hi. The returned string will
+-- be in the following format:
+--
+-- " block_name
+-- hi ...
+-- hi ...
+--
+-- The block name is either the first value in the list (highlight_blocks) or the name of the
+-- option group (option_groups). The option groups are sorted by name to avoid unnecessary Git
+-- diffs.
+--
+-- Highlight groups are sorted by name as a convention only. The first
+-- highlight group in the first block must be Normal, and it will be sorted to
+-- the top of the list.
+M.make_theme = function(term_colors, option_groups, highlight_blocks)
+	local out = {
+		[[
+set background=light
+
+if !has('gui_running') && &t_Co < 256 && !has('nvim')
+  finish
+endif
+
+hi clear
+if exists('syntax_on')
+  syntax reset
+endif
+
+let g:colors_name = 'yui'
+  ]],
+	}
+
+	table.insert(out, M.make_term(term_colors))
+	table.insert(out, "")
+
+	for _, block in ipairs(highlight_blocks) do
+		local block_name = table.remove(block, 1)
+		table.insert(out, string.format('" %s', block_name))
+		table.sort(block, function(a, b)
+			if "Normal" == a.name then
+				return true
+			elseif "Normal" == b.name then
+				return false
+			end
+			return a.name < b.name
+		end)
+		for _, group in pairs(block) do
+			table.insert(out, M.make_hi(group))
+		end
+		table.insert(out, "")
+	end
+
+	for _, opt in ipairs(option_groups) do
+		table.insert(out, string.format('" %s', opt.name))
+		table.insert(out, M.make_opt_hi(opt))
+		table.insert(out, "")
+	end
+
+	return table.concat(out, "\n")
+end
+
+-- Generate the Vim help text for the given option groups. Each option group is a table
+-- with various fields. The fields that are used to generate the docs are:
+--  - name: The name of the option group
+--  - description: A description of the option group
+--  - default: The default value of the option group
+--  - cases: A table of tables which contains the value and description of each
+--           option in the group
+-- Each option group is converted into a Vim help section. The section name is the name.
+-- The description is used as the section description. The default value is used as the
+-- default value for the option group. Each option in the group is converted into a
+-- Vim help sub-section. The sub-section name is the value of the option. The description
+-- is used as the sub-section description.
+M.make_docs = function(option_groups)
+	local line_length = 78
+	local docs = {
+		-- Generate a line that consists of the following:
+		-- 1. The string "*yui.txt*"
+		-- 2. As many spaces as necessary to make the line 78 characters long
+		-- 3. The string "A minimal colorscheme for Vim and Neovim"
+		string.format("*yui.txt*%sA minimal colorscheme for Vim and Neovim", string.rep(" ", line_length - 9 - 40)),
+		"",
+		"YUI | ユイ",
+		"",
+	}
+	table.insert(docs, string.format("%s", string.rep("=", line_length)))
+
+	-- insert the word OPTIONS, then as many spaces as necessary, then the
+	-- string '*yui-options*', so that the entire line is 78 characters
+	-- long. This is the format that Vim expects for help tags.
+	table.insert(docs, string.format("OPTIONS%s%s", string.rep(" ", line_length - 8 - 12), "*yui-options*"))
+	table.insert(docs, "")
+
+	for i, group in ipairs(option_groups) do
+		if i ~= 1 then
+			table.insert(docs, string.rep("-", line_length))
+		end
+
+		local option_tag_format_string = "%" .. line_length .. "s"
+		local vim_tag = string.format("*g:%s*", group.name)
+		table.insert(docs, string.format(option_tag_format_string, vim_tag))
+		table.insert(docs, "")
+
+		-- Headings are done by appending a tilde to the end of the line. In :h help-writing,
+		-- this is described as a Column heading.
+		table.insert(docs, string.format("g:%s~", group.name))
+		table.insert(docs, "")
+
+		-- If the option group has a field named "deprecated", then that field
+		-- should be a string that contains the reason why the option group is
+		-- deprecated. If the option group is deprecated, then add a note to the
+		-- help text.
+		if group.deprecated ~= nil then
+			table.insert(docs, string.format("DEPRECATED: %s\n", group.deprecated))
+		end
+
+		table.insert(docs, group.description)
+		-- Insert each case of the option group including the value and description
+		-- of the option. Sort the cases by their key, to avoid unnecessary diffs.
+		local case_keys = {}
+		for key, _ in pairs(group.cases) do
+			table.insert(case_keys, key)
+		end
+		table.sort(case_keys)
+
+		for _, key in ipairs(case_keys) do
+			local case = group.cases[key]
+			local key_str = tostring(key)
+			local is_default = key == group.default
+			local description = case.description
+			if is_default then
+				description = string.format("%s (default)", description)
+			end
+			local line = string.format(
+				"* %s:%s%s",
+				key_str,
+				string.rep(" ", line_length - 4 - #key_str - #description),
+				description
+			)
+			table.insert(docs, line)
+		end
+
+		table.insert(docs, "")
+		-- If the option group does not have a field called "example",
+		-- then the example is generated from the name of the option group,
+		-- and the default case. The example is a string that can be used
+		-- to set the option group in Vim.
+		local example = group.example
+		if example == nil then
+			example = string.format(
+				[[Example: >
+  let g:%s = %s
+<]],
+				group.name,
+				group.default
+			)
+		else
+			example = string.format(
+				[[Example: >
+%s
+<]],
+				example
+			)
+		end
+		table.insert(docs, example)
+		table.insert(docs, "")
+	end
+
+	-- Without the additional space, the modeline isn't recognized.
+	-- Adding the space in the string literal doesn't work, since Vim/Neovim
+	-- will then parse the modeline and fail on the closing quote and parenthesis.
+	table.insert(docs, " " .. "vim:tw=78:et:ft=help:norl:")
+	return table.concat(docs, "\n")
+end
+
+return M

--- a/template/yui.lua
+++ b/template/yui.lua
@@ -1,0 +1,538 @@
+local M = {}
+
+local theme = require("theme")
+local hsluv = require("hsluv")
+
+-- http://blog.presentandcorrect.com/rams-palettes
+-- https://news.ycombinator.com/item?id=26318379
+local rams = {
+	dr01 = {
+		light_blue = "#aab7bf",
+		brown = "#736356",
+		white = "#bfb1a8",
+		red = "#ad1d1d",
+		black = "#261201",
+	},
+	dr03 = {
+		orange = "#bf7c2a",
+		taupe = "#c09c6f",
+		dark_gray = "#5f503e",
+		light_gray = "#9c9c9c",
+		white = "#e1e4e1",
+	},
+	dr04 = {
+		olive = "#84764b",
+		green = "#b7b183",
+		black = "#372e2d",
+		light_gray = "#bcb3a6",
+		white = "#dbd7d3",
+	},
+	dr06 = {
+		tangerine = "#ed8008",
+		orange = "#ed3f1c",
+		red = "#bf1b1b",
+		green = "#736b1e",
+		white = "#d9d2c6",
+	},
+}
+
+local old_yui_colors = {
+	white = "#efeae5",
+	purple = "#dcd7f9",
+}
+
+local palette = {
+	blue = rams.dr01.light_blue,
+	green = rams.dr04.green,
+	red = rams.dr01.red,
+	yellow = rams.dr03.orange,
+	black = rams.dr03.dark_gray,
+	white = old_yui_colors.white,
+	accent = old_yui_colors.purple,
+	alternative_accent = rams.dr06.orange,
+}
+
+local function lightness(color, amount)
+	local color_hsluv = hsluv.hex_to_hsluv(color)
+	color_hsluv[3] = color_hsluv[3] + amount
+	return hsluv.hsluv_to_hex(color_hsluv)
+end
+
+local c = {
+	accent1 = lightness(palette.accent, -65),
+	accent2 = lightness(palette.accent, -50),
+	accent3 = lightness(palette.accent, -35),
+	accent4 = lightness(palette.accent, -15),
+	accent5 = lightness(palette.accent, 0),
+	black1 = lightness(palette.black, -10),
+	black2 = lightness(palette.black, 0),
+	black3 = lightness(palette.black, 7),
+	black4 = lightness(palette.black, 14),
+	dark_blue = lightness(palette.blue, -40),
+	dark_green = lightness(palette.green, -40),
+	dark_red = lightness(palette.red, -30),
+	dark_yellow = lightness(palette.yellow, -20),
+	light_blue = lightness(palette.blue, 15),
+	light_green = lightness(palette.green, 15),
+	light_red = lightness(palette.red, 40),
+	light_yellow = lightness(palette.yellow, 38),
+	alternative_accent = lightness(palette.alternative_accent, 0),
+	white1 = lightness(palette.white, -12),
+	white2 = lightness(palette.white, -7),
+	white3 = lightness(palette.white, -2),
+	white4 = lightness(palette.white, 3),
+	white5 = lightness(palette.white, 6),
+}
+
+M.groups = {
+
+	{
+		"UI & Syntax",
+		{ name = "Normal", guifg = c.black2, guibg = c.white4 },
+		{ name = "NormalNC", link = "Normal" },
+		{ name = "MsgArea", link = "Normal" },
+		{ name = "ColorColumn", guifg = "fg", guibg = c.white3 },
+		{ name = "Conceal", guifg = c.white1, guibg = "NONE" },
+		{ name = "CursorColumn", guifg = "NONE", guibg = c.white5 },
+		{ name = "Cursor", guifg = "bg", guibg = "fg" },
+		{ name = "CursorIM", guifg = "NONE", guibg = "fg" },
+		{ name = "CursorLine", guifg = "fg", guibg = c.white5 },
+		{ name = "CursorLineNr", guifg = "fg", guibg = c.white5 },
+		{ name = "DiffAdd", guifg = c.dark_green, guibg = c.light_green },
+		{ name = "DiffChange", guifg = c.dark_yellow, guibg = c.light_yellow },
+		{ name = "DiffDelete", guifg = c.dark_red, guibg = c.light_red, gui = "NONE" },
+		{ name = "DiffText", guifg = c.dark_blue, guibg = c.light_blue },
+		{ name = "Directory", guifg = "fg", guibg = "NONE" },
+		{ name = "Error", link = "DiffDelete" },
+		{ name = "ErrorMessage", link = "DiffDelete" },
+		{ name = "ErrorMsg", link = "DiffDelete" },
+		{ name = "Identifier", guifg = "fg", guibg = "NONE" },
+		{ name = "Ignore", guifg = "fg", guibg = "NONE" },
+		{ name = "IncSearch", guifg = c.accent5, guibg = c.accent2 },
+		{ name = "InfoMsg", guifg = c.accent2, guibg = c.accent5 },
+		{ name = "MatchParen", guifg = "NONE", guibg = c.white2 },
+		{ name = "TabLineSel", guifg = "fg", guibg = c.white2 },
+		{ name = "TabLine", link = "Pmenu" },
+		{ name = "TabLineFill", link = "StatusLineNC" },
+		{ name = "ModeMsg", guifg = "fg", guibg = "NONE" },
+		{ name = "MoreMsg", guifg = "fg", guibg = "NONE" },
+		{ name = "NonText", guifg = "fg", guibg = "NONE" },
+		{ name = "Pmenu", guifg = "NONE", guibg = c.white3 },
+		{ name = "PmenuThumb", guifg = "NONE", guibg = "fg" },
+		{ name = "PreProc", guifg = "fg", guibg = "NONE" },
+		{ name = "Question", guifg = "fg", guibg = "NONE" },
+		{ name = "Search", guifg = c.accent2, guibg = c.accent5 },
+		{ name = "CurSearch", guifg = c.accent5, guibg = c.accent3 },
+		{ name = "Visual", guifg = c.accent1, guibg = c.accent4 },
+		{ name = "Special", guifg = "fg", guibg = "NONE" },
+		{ name = "SpecialKey", guifg = "fg", guibg = "NONE" },
+		{ name = "SpellBad", link = "DiffDelete" },
+		{ name = "SpellCap", guifg = "NONE", guibg = "NONE", guisp = c.light_red, gui = "undercurl" },
+		{ name = "SpellLocal", guifg = "fg", guibg = "NONE" },
+		{ name = "SpellRare", guifg = "fg", guibg = "NONE" },
+		{ name = "Statement", guifg = "fg", guibg = "NONE", gui = "italic" },
+		{ name = "StatusLine", guifg = c.white2, guibg = c.black1, gui = "reverse" },
+		{ name = "StatusLineNC", guifg = c.white3, guibg = c.black2 },
+		{ name = "Terminal", guifg = "fg", guibg = "bg" },
+		{ name = "Todo", link = "WarningMsg" },
+		{ name = "ToolbarButton", guifg = "fg", guibg = "NONE" },
+		{ name = "ToolbarLine", guifg = "NONE", guibg = "NONE" },
+		{ name = "Type", guifg = "NONE", guibg = "NONE", gui = "italic" },
+		{ name = "Underlined", guifg = "fg", guibg = "NONE", gui = "underline" },
+		{ name = "VertSplit", guifg = c.white1, guibg = "NONE" },
+		{ name = "VisualNOS", guifg = "NONE", guibg = c.white5 },
+		{ name = "WarningMsg", link = "DiffChange" },
+		{ name = "Whitespace", guifg = c.black4, guibg = "NONE" },
+		{ name = "Tooltip", guifg = "fg", guibg = c.white3 },
+		{ name = "Menu", guifg = "fg", guibg = c.white3 },
+		{ name = "Scrollbar", guifg = "NONE", guibg = c.white3 },
+		{ name = "Title", guifg = "fg", guibg = "NONE" },
+		{ name = "NormalNC", link = "Normal" },
+		{ name = "WinBar", link = "TabLineSel" },
+		{ name = "WinBarNC", link = "TabLine" },
+		{ name = "MsgSeparator", link = "VertSplit" },
+		{ name = "EndOfBuffer", link = "NonText" },
+		{ name = "QuickFixLine", link = "Search" },
+		{ name = "PmenuSel", link = "WildMenu" },
+		{ name = "StatusLineTerm", link = "StatusLine" },
+		{ name = "StatusLineTermNC", link = "StatusLineNC" },
+		{ name = "lCursor", link = "Cursor" },
+		{ name = "PmenuSbar", link = "Pmenu" },
+		{ name = "WildMenu", link = "Visual" },
+		{ name = "Boolean", link = "Constant" },
+		{ name = "Character", link = "Constant" },
+		{ name = "Conditional", link = "Statement" },
+		{ name = "Define", link = "PreProc" },
+		{ name = "Debug", link = "Special" },
+		{ name = "Delimiter", link = "Special" },
+		{ name = "Float", link = "Number" },
+		{ name = "Function", link = "Identifier" },
+		{ name = "Include", link = "PreProc" },
+		{ name = "Macro", link = "PreProc" },
+		{ name = "Number", link = "Constant" },
+		{ name = "PreCondit", link = "PreProc" },
+		{ name = "SpecialChar", link = "Special" },
+		{ name = "SpecialComment", link = "Special" },
+		{ name = "StorageClass", link = "Type" },
+		{ name = "String", link = "Constant" },
+		{ name = "Structure", link = "Type" },
+		{ name = "Tag", link = "Special" },
+		{ name = "Typedef", link = "Type" },
+		{ name = "Substitute", link = "IncSearch" },
+		{ name = "Operator", guifg = "fg", guibg = "NONE" },
+		{ name = "Repeat", guifg = "fg", guibg = "NONE" },
+		{ name = "Constant", guifg = c.black1, guibg = "NONE" },
+		{ name = "jsParensError", guifg = "fg", guibg = "NONE" },
+		{ name = "Exception", guifg = "fg", guibg = "NONE" },
+		{ name = "Keyword", guifg = "fg", guibg = "NONE" },
+		{ name = "Label", guifg = "fg", guibg = "NONE" },
+	},
+
+	{
+		"Floating Windows",
+		{ name = "NormalFloat", guifg = "fg", guibg = c.white3 },
+		{ name = "FloatTitle", guifg = "fg", guibg = c.white3, gui = "bold" },
+		{ name = "FloatBorder", guifg = "fg", guibg = c.white3 },
+	},
+
+	{
+		"Diagnostic",
+		{ name = "DiagnosticError", link = "Error" },
+		{ name = "DiagnosticWarn", link = "WarningMsg" },
+		{ name = "DiagnosticInfo", link = "DiffText" },
+		{ name = "DiagnosticHint", guifg = c.black2, guibg = "NONE" },
+		{ name = "DiagnosticUnderlineError", link = "Error" },
+		{ name = "DiagnosticUnderlineWarn", link = "WarningMsg" },
+		{ name = "DiagnosticUnderlineInfo", link = "DiffText" },
+		{ name = "DiagnosticUnderlineHint", link = "Normal" },
+		{ name = "DiagnosticSignError", guifg = c.dark_red, guibg = "NONE", gui = "NONE" },
+		{ name = "DiagnosticSignWarn", guifg = c.dark_yellow, guibg = "NONE", gui = "NONE" },
+		{ name = "DiagnosticSignInfo", guifg = c.dark_blue, guibg = "NONE", gui = "NONE" },
+		{ name = "DiagnosticSignHint", guifg = "fg", guibg = "NONE", gui = "NONE" },
+	},
+
+	{ "LSP", { name = "LspSignatureActiveParameter", link = "Search" } },
+
+	{
+		"Vim Script",
+		{ name = "vimGroup", link = "Normal" },
+		{ name = "vimHiGui", link = "Normal" },
+		{ name = "vimHiKeyList", link = "Normal" },
+		{ name = "vimHiGroup", link = "Normal" },
+		{ name = "vimHiCTerm", link = "Normal" },
+		{ name = "vimHiCTermFgBg", link = "Normal" },
+		{ name = "vimHiGuiFgBg", link = "Normal" },
+	},
+
+	{
+		"Typescript",
+		{ name = "typescriptParens", guifg = "fg", guibg = "NONE" },
+	},
+
+	{
+		"Markdown",
+		{ name = "mkHeading", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "mkItalic", guifg = "NONE", guibg = "NONE", gui = "italic" },
+		{ name = "markdownBold", guifg = "NONE", guibg = "NONE", gui = "bold" },
+		{ name = "markdownUrl", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "markdownUrl", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "markdownHeadingDelimiter", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "mkCode", guifg = "fg", guibg = "NONE" },
+		{ name = "mkdCodeDelimiter", link = "mkCode" },
+		{ name = "markdownItalic", link = "mkItalic" },
+		{ name = "markdownLinkText", guifg = "fg", guibg = "NONE" },
+		{ name = "markdownH1", link = "mkdHeading" },
+		{ name = "markdownH1Delimiter", link = "markdownHeadingDelimiter" },
+		{ name = "markdownH2", link = "mkdHeading" },
+		{ name = "markdownH3", link = "mkdHeading" },
+		{ name = "markdownH4", link = "mkdHeading" },
+		{ name = "markdownCodeDelimiter", guifg = "NONE", guibg = "NONE" },
+		{ name = "markdownBoldDelimiter", guifg = "NONE", guibg = "NONE" },
+		{ name = "markdownItalicDelimiter", guifg = "NONE", guibg = "NONE" },
+		{ name = "markdownBoldItalicDelimiter", guifg = "NONE", guibg = "NONE" },
+		{ name = "markdownLinkDelimiter", guifg = "NONE", guibg = "NONE" },
+		{ name = "markdownLinkTextDelimiter", guifg = "NONE", guibg = "NONE" },
+	},
+
+	{
+		"Help Text",
+		{ name = "helpBacktick", link = "Constant" },
+		{ name = "helpCommand", link = "Constant" },
+		{ name = "helpDeprecated", link = "Error" },
+		{ name = "helpExample", guifg = c.black1, guibg = c.white3, gui = "NONE" },
+		{ name = "helpHeader", guifg = "NONE", guibg = "NONE", gui = "bold" },
+		{ name = "helpHeadline", guifg = c.black1, guibg = "NONE", gui = { "bold" } },
+		{ name = "helpHyperTextEntry", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "helpHyperTextJump", guifg = "NONE", guibg = "NONE", gui = "underline" },
+		{ name = "helpNote", guifg = "NONE", guibg = "NONE", gui = "bold" },
+		{ name = "helpOption", guifg = "NONE", guibg = "NONE", gui = "bold" },
+		{ name = "helpSectionDelim", guifg = c.black4, guibg = "NONE", gui = "NONE" },
+		{ name = "helpSpecial", guifg = "NONE", guibg = "NONE", gui = "bold" },
+    { name = "helpURL", guifg = "NONE", guibg = "NONE", gui = "underline" },
+	},
+
+	{
+		"Help Text TS",
+    { name = "@text.literal", link = "helpExample" },
+    { name = "@text.reference", link = "helpOption" },
+	},
+
+	{
+		"XML",
+		{ name = "xmlProcessingDelim", link = "Normal" },
+		{ name = "xmlTagName", guifg = "NONE", guibg = "NONE", gui = "NONE" },
+	},
+
+	{
+		"fugitive",
+		{ name = "fugitiveStagedSection", guifg = "fg", guibg = "NONE", gui = { "underline", "bold" } },
+		{ name = "fugitiveUnstagedSection", guifg = "fg", guibg = "NONE", gui = { "underline", "bold" } },
+		{ name = "diffAdded", link = "DiffAdd" },
+		{ name = "diffLine", guifg = "fg", guibg = "NONE", gui = "bold" },
+		{ name = "gitHashAbbrev", guifg = "fg", guibg = "NONE", gui = "underline" },
+		{ name = "diffChanged", link = "DiffChange" },
+		{ name = "diffRemoved", link = "DiffDelete" },
+		{ name = "diffComment", link = "Comment" },
+		{ name = "diffSubname", guifg = "fg", guibg = "NONE", gui = "bold" },
+	},
+
+	{
+		"Git Signs",
+		{ name = "GitSignsAdd", link = "DiffAdd" },
+		{ name = "GitSignsAddNr", link = "DiffAdd" },
+		{ name = "GitSignsAddLn", link = "DiffAdd" },
+		{ name = "GitSignsChange", link = "DiffChange" },
+		{ name = "GitSignsChangeNr", link = "DiffChange" },
+		{ name = "GitSignsChangeLn", link = "DiffChange" },
+		{ name = "GitSignsDelete", link = "DiffDelete" },
+		{ name = "GitSignsDeleteNr", link = "DiffDelete" },
+		{ name = "GitSignsDeleteLn", link = "DiffDelete" },
+	},
+
+	{ "Indent Blank Line", { name = "IndentBlanklineChar", link = "VertSplit" } },
+	{
+		"Sneak",
+		{ name = "Sneak", link = "Visual" },
+		{ name = "SneakScope", link = "IncSearch" },
+		{ name = "SneakLabel", link = "Search" },
+	},
+
+	{
+		"Dirvish",
+		{ name = "DirvishPathTail", guifg = "NONE", guibg = "NONE", gui = "bold" },
+		{ name = "DirvishArg", link = "Search" },
+	},
+
+	{
+		"HL Search Lens",
+		{ name = "HlSearchLensNear", link = "StatusLine" },
+		{ name = "HlSearchLens", link = "StatusLineNC" },
+		{ name = "HlSearchNear", link = "Search" },
+	},
+
+	{
+		"Conflict Marker",
+		{ name = "ConflictMarkerBegin", link = "DiffAdd" },
+		{ name = "ConflictMarkerOurs", link = "DiffAdd" },
+		{ name = "ConflictMarkerTheirs", link = "DiffText" },
+		{ name = "ConflictMarkerEnd", link = "DiffText" },
+	},
+
+	{
+		"Treesitter Context",
+		{ name = "TreesitterContextBottom", gui = "underline" },
+		{ name = "TreesitterContext", link = "Pmenu" },
+	},
+
+	{
+		"Which Key",
+		{ name = "WhichKeySeperator", guifg = "fg", guibg = "NONE" },
+		{ name = "WhichKeyFloating", link = "Pmenu" },
+	},
+
+	{
+		"Leap",
+		{ name = "LeapMatch", guifg = c.dark_blue, guibg = c.light_blue, gui = "none" },
+		{ name = "LeapLabelPrimary", guifg = "#ffffff", guibg = c.alternative_accent, gui = "bold" },
+		{ name = "LeapLabelSecondary", guifg = c.light_yellow, guibg = c.dark_yellow, gui = "none" },
+		{ name = "LeapLabelSelected", guifg = c.dark_red, guibg = c.light_red, gui = "none" },
+	},
+}
+
+local lightline = {
+	normal = {
+		left = { { c.light_green, c.dark_green }, { c.white4, c.black3 } },
+		right = { { c.white4, c.black2 }, { c.white4, c.black3 }, { c.black1, c.black4 } },
+		middle = { { c.black2, c.black4 } },
+		error = { { c.dark_red, c.light_red } },
+		warning = { { c.light_yellow, c.dark_yellow } },
+	},
+	insert = {
+		left = { { c.light_blue, c.dark_blue }, { c.white4, c.black3 } },
+	},
+	visual = {
+		left = { { c.accent5, c.accent2 }, { c.white4, c.black3 } },
+	},
+	replace = {
+		left = { { c.white5, c.alternative_accent }, { c.white4, c.black3 } },
+	},
+	inactive = {
+		right = { { c.black3, c.white1 }, { c.black3, c.white1 }, { c.black3, c.white1 } },
+		middle = { { c.black3, c.white2 } },
+	},
+	tabline = {
+		middle = { { c.black2, c.white4 } },
+	},
+}
+lightline.inactive.left = { table.unpack(lightline.inactive.right, 2) }
+lightline.tabline.left = lightline.inactive.middle
+lightline.tabline.tabsel = { table.unpack(lightline.normal.left, 2) }
+
+M.option_groups = {
+	{
+		name = "yui_folds",
+		description = [[
+How folds should be displayed]],
+		default = "'fade'",
+		cases = {
+			["'emphasize'"] = {
+				description = [[
+Make folds more visible]],
+				groups = {
+					{ name = "FoldColumn", guifg = c.black3, guibg = c.white2 },
+					{ name = "Folded", guifg = c.black3, guibg = c.white2 },
+				},
+			},
+			["'fade'"] = {
+				description = [[
+Fade out folds]],
+				groups = {
+					{ name = "FoldColumn", guifg = c.black4, guibg = "NONE" },
+					{ name = "Folded", guifg = c.black4, guibg = "NONE" },
+				},
+			},
+		},
+	},
+	{
+		name = "yui_line_numbers",
+		default = "'fade'",
+		description = [[
+How line numbers should be displayed]],
+		cases = {
+			["'emphasize'"] = {
+				description = [[
+Make line numbers more visible]],
+				groups = {
+					{ name = "SignColumn", guifg = c.black3, guibg = c.white2 },
+					{ name = "LineNr", guifg = c.black3, guibg = c.white2 },
+				},
+			},
+			["'fade'"] = {
+				description = [[
+Fade out line numbers]],
+				groups = {
+					{ name = "SignColumn", guifg = "fg", guibg = "bg" },
+					{ name = "LineNr", guifg = c.black4, guibg = "NONE" },
+				},
+			},
+		},
+	},
+	-- This has to come before yui_comments, so that yui_comments can override it.
+	{
+		name = "yui_emphasized_comments",
+		default = "0",
+		deprecated = [[
+Use |yui_comments| instead]],
+		description = [[
+Whether to emphasize comments]],
+		cases = {
+			[1] = {
+				description = [[
+Emphasize comments]],
+				groups = {
+					{ name = "Comment", guifg = c.alternative_accent, guibg = "NONE", gui = "italic" },
+				},
+			},
+			[0] = {
+				description = [[
+Do not emphasize comments]],
+				groups = {
+					{ name = "Comment", guifg = c.black3, guibg = "NONE", gui = "italic" },
+				},
+			},
+		},
+	},
+	{
+		name = "yui_comments",
+		default = "'normal'",
+		description = [[
+How comments should be displayed]],
+		cases = {
+			["'emphasize'"] = {
+				description = [[
+Emphasize comments]],
+				groups = {
+					{ name = "Comment", guifg = c.alternative_accent, guibg = "NONE", gui = "italic" },
+				},
+			},
+			["'fade'"] = {
+				description = [[
+Fade out comments]],
+				groups = {
+					{ name = "Comment", guifg = c.black3, guibg = "NONE", gui = "italic" },
+				},
+			},
+			["'normal'"] = {
+				description = [[
+Do not emphasize comments]],
+				groups = {
+					{ name = "Comment", guifg = c.black3, guibg = "NONE", gui = "italic" },
+				},
+			},
+			["'bg'"] = {
+				description = [[
+Make comments have a background color]],
+				groups = {
+					{ name = "Comment", guifg = "fg", guibg = c.white3, gui = "NONE" },
+				},
+			},
+		},
+	},
+	{
+		name = "yui_lightline",
+		default = "v:false",
+		example = [[
+  let g:yui_lightline = v:true
+  let g:lightline.colorscheme = 'yui']],
+		description = [[
+Whether to use the lightline theme]],
+		cases = {
+			["v:true"] = {
+				description = [[
+Use the lightline theme]],
+				groups = { table.unpack(theme.make_lightline(lightline)) },
+			},
+		},
+	},
+}
+
+M.term_colors = {
+	c.black2,
+	c.light_red,
+	c.dark_green,
+	c.dark_yellow,
+	"#00588f",
+	c.accent2,
+	c.dark_blue,
+	c.white4,
+	c.black2,
+	c.light_red,
+	c.dark_green,
+	c.dark_yellow,
+	"#00588f",
+	c.accent3,
+	c.dark_blue,
+	c.white4,
+}
+
+return M


### PR DESCRIPTION
This is a big change!

The original idea behind this theme was twofold: use as few colors as is reasonable and get some inspiration from the design philosophy of Dieter Rams. The latter point rested mostly on a "Rams Notebook" I once saw, which had the distinctive orange color on brown/beige paper.

This PR adds a palette to the theme, which takes inspiration from a bigger [palette of Rams colors](http://blog.presentandcorrect.com/rams-palettes).

I also added a light weight, custom template system. This lets me define a palette and then adjust the lightness of the colors to generate a larger set of colors, from which the actual theme is then built. This should make it easier to give the theme a more coherent feeling. I'd like to explore this further in the future, and try to move the theme closer to a rams palette. Arguably, it should have been called "Rams" not "YUI".

The template system would also let me run a few basic checks, such as W3C contrast checks. I'd really like to make this as accessible as possible.

Eventually I'd also love to deprecate the purple color. Somehow I find it a bit garish nowadays. But I'm not sure if this would upset people.

The README is smaller, there's a CONTRIBUTING file, a LICENSE, and the docs are automatically generated now.