### PR TITLE
feat: support Telescope

### DIFF
--- a/template/yui.lua
+++ b/template/yui.lua
@@ -361,6 +361,12 @@ M.groups = {
 		{ name = "LeapLabelSecondary", guifg = c.light_yellow, guibg = c.dark_yellow, gui = "none" },
 		{ name = "LeapLabelSelected", guifg = c.dark_red, guibg = c.light_red, gui = "none" },
 	},
+
+	{
+		"Telescope",
+		{ name = "TelescopeMatching", guifg = c.accent5, guibg = c.accent3, gui = "NONE" },
+		{ name = "TelescopeSelection", guifg = c.accent2, guibg = c.accent5, gui = "NONE" },
+	}
 }
 
 local lightline = {


### PR DESCRIPTION
For now it's just better representation of search query. Basically, this is an inverted logic for Search and CurSearch. In my opinion, inverted colors better suits Telescope's fuzzy searching.

But you, as theme author, can change it as you want ofc.

I also suggest to review other default Telescope's highlights, provided here: https://github.com/nvim-telescope/telescope.nvim/blob/master/plugin/telescope.lua#L11

May be that search counter is too bold, etc.

Resolves: #28 

<img width="1429" alt="Screenshot 2023-04-05 at 17 36 35" src="https://user-images.githubusercontent.com/15351892/230114736-2619e0e5-0aba-4eba-986e-a6184f685d85.png">


P.S. For contributing purpose, consider `.editorconfig` (same indentation type, so on). Neovim supports it by default.