### PR TITLE
Improve Lightline colors

### DIFF
--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -344,54 +344,54 @@ if s:yui_lightline_value ==? v:true
 	let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 	let s:p.visual.left = [
 		\['#dcd7f9', '#6132d7', 189, 62],
-		\['#f6f3f0', '#72604b', 255, 59],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.tabline.tabsel = [
-		\['#f6f3f0', '#72604b', 255, 59],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.tabline.middle = [
-		\['#5f503e', '#f6f3f0', 239, 255],
+		\['#524535', '#eae4dd', 238, 254],
 		\]
 	let s:p.tabline.left = [
-		\['#72604b', '#e0d5ca', 59, 188],
+		\['#7a6851', '#eae4dd', 95, 254],
 		\]
 	let s:p.replace.left = [
 		\['#fdfcfb', '#ed3f1c', 231, 202],
-		\['#f6f3f0', '#72604b', 255, 59],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.normal.warning = [
 		\['#fef0e8', '#7c4f18', 255, 94],
 		\]
 	let s:p.normal.right = [
-		\['#f6f3f0', '#5f503e', 255, 239],
-		\['#f6f3f0', '#72604b', 255, 59],
-		\['#453a2c', '#867159', 237, 95],
+		\['#392f23', '#d6c6b6', 236, 187],
+		\['#392f23', '#d6c6b6', 236, 187],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.normal.middle = [
-		\['#5f503e', '#867159', 239, 95],
+		\['#524535', '#eae4dd', 238, 254],
 		\]
 	let s:p.normal.left = [
-		\['#e2dba3', '#4e4b36', 187, 238],
-		\['#f6f3f0', '#72604b', 255, 59],
+		\['#4e4b36', '#e2dba3', 238, 187],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.normal.error = [
-		\['#350303', '#f8acac', 233, 217],
+		\['#f8acac', '#350303', 217, 233],
 		\]
 	let s:p.insert.left = [
-		\['#d9e0e3', '#4a5054', 253, 239],
-		\['#f6f3f0', '#72604b', 255, 59],
+		\['#4a5054', '#d9e0e3', 239, 253],
+		\['#453a2c', '#e0d5ca', 237, 188],
 		\]
 	let s:p.inactive.right = [
-		\['#72604b', '#d6c7b6', 59, 187],
-		\['#72604b', '#d6c7b6', 59, 187],
-		\['#72604b', '#d6c7b6', 59, 187],
+		\['#7a6851', '#eae4dd', 95, 254],
+		\['#7a6851', '#eae4dd', 95, 254],
+		\['#7a6851', '#eae4dd', 95, 254],
 		\]
 	let s:p.inactive.middle = [
-		\['#72604b', '#e0d5ca', 59, 188],
+		\['#7a6851', '#eae4dd', 95, 254],
 		\]
 	let s:p.inactive.left = [
-		\['#72604b', '#d6c7b6', 59, 187],
-		\['#72604b', '#d6c7b6', 59, 187],
+		\['#7a6851', '#eae4dd', 95, 254],
+		\['#7a6851', '#eae4dd', 95, 254],
 		\]
 	let g:lightline#colorscheme#yui#palette = s:p
 endif

--- a/template/yui.lua
+++ b/template/yui.lua
@@ -437,29 +437,73 @@ M.groups = {
 	},
 }
 
+-- higher index = darker, meaning lightline components towards the side of the
+-- statusline should use higher indexes
+local lightline_bg_shades = {}
+local lightline_fg_shades = {}
+
+-- Find StatusLine color
+for _, block in ipairs(M.groups) do
+	for _, highlight in ipairs(block.groups) do
+		if type(highlight) == "table" and highlight.name == "StatusLine" then
+			-- StatusLine uses "reverse", hence the bg = fg
+			local base_bg = highlight.guifg
+			local base_fg = highlight.guibg
+
+			-- Since we darken the background towards the sides, we should lighten
+			-- the StatusLine color a bit, otherwise it'll get very dark towards
+			-- the sides
+			for i, factor in ipairs({ 5, 0, -5 }) do
+				lightline_bg_shades[i] = lightness(base_bg, factor)
+				lightline_fg_shades[i] = lightness(base_fg, factor)
+			end
+			break
+		end
+	end
+end
+
+local lightline_bg_shades_inactive = {
+	lightline_bg_shades[1],
+	lightline_bg_shades[1],
+	lightline_bg_shades[1],
+}
+local lightline_fg_shades_inactive = {
+	lightness(lightline_fg_shades[1], 15),
+	lightness(lightline_fg_shades[1], 15),
+	lightness(lightline_fg_shades[1], 15),
+}
+
 local lightline = {
 	normal = {
-		left = { { c.light_green, c.dark_green }, { c.white4, c.black3 } },
-		right = { { c.white4, c.black2 }, { c.white4, c.black3 }, { c.black1, c.black4 } },
-		middle = { { c.black2, c.black4 } },
-		error = { { c.dark_red, c.light_red } },
+		left = { { c.dark_green, c.light_green }, { lightline_fg_shades[2], lightline_bg_shades[2] } },
+		right = {
+			{ lightline_fg_shades[3], lightline_bg_shades[3] },
+			{ lightline_fg_shades[3], lightline_bg_shades[3] },
+			{ lightline_fg_shades[2], lightline_bg_shades[2] },
+		},
+		middle = { { lightline_fg_shades[1], lightline_bg_shades[1] } },
+		error = { { c.light_red, c.dark_red } },
 		warning = { { c.light_yellow, c.dark_yellow } },
 	},
 	insert = {
-		left = { { c.light_blue, c.dark_blue }, { c.white4, c.black3 } },
+		left = { { c.dark_blue, c.light_blue }, { lightline_fg_shades[2], lightline_bg_shades[2] } },
 	},
 	visual = {
-		left = { { c.accent5, c.accent2 }, { c.white4, c.black3 } },
+		left = { { c.accent5, c.accent2 }, { lightline_fg_shades[2], lightline_bg_shades[2] } },
 	},
 	replace = {
-		left = { { c.white5, c.alternative_accent }, { c.white4, c.black3 } },
+		left = { { c.white5, c.alternative_accent }, { lightline_fg_shades[2], lightline_bg_shades[2] } },
 	},
 	inactive = {
-		right = { { c.black3, c.white1 }, { c.black3, c.white1 }, { c.black3, c.white1 } },
-		middle = { { c.black3, c.white2 } },
+		right = {
+			{ lightline_fg_shades_inactive[3], lightline_bg_shades_inactive[3] },
+			{ lightline_fg_shades_inactive[3], lightline_bg_shades_inactive[3] },
+			{ lightline_fg_shades_inactive[2], lightline_bg_shades_inactive[2] },
+		},
+		middle = { { lightline_fg_shades_inactive[1], lightline_bg_shades_inactive[1] } },
 	},
 	tabline = {
-		middle = { { c.black2, c.white4 } },
+		middle = { { lightline_fg_shades[1], lightline_bg_shades[1] } },
 	},
 }
 lightline.inactive.left = { table.unpack(lightline.inactive.right, 2) }


### PR DESCRIPTION
The current lightline colors are way too dark. This commit generally lightens the colors, so that we can then darken them as we go from center to the sides.

First, we find the StatusLine guibg and lighten it a bit.

Then we define 5 shades, from middle to sides. The shades are based on the base colors, which are StatusLine (lightened) and c.black1.

This basically implements what I already had in https://github.com/cideM/yui/pull/32#issuecomment-1511035457

<img width="856" alt="Screenshot 2023-04-28 at 11 08 19" src="https://user-images.githubusercontent.com/4246921/235110569-96d4f572-4f16-47ad-b1b1-24fa0a820dd0.png">
