### PR TITLE
Add conditional combinators for And, Or and Cond

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,2 @@
+call_parentheses = "NoSingleTable"
+column_width = 100

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -226,7 +226,7 @@ hi helpSpecial guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=bold cterm=bo
 hi helpURL guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
 
 " Help Text TS
-if has('nvim')
+if (has('nvim'))
 	hi! link @text.literal helpExample
 	hi! link @text.reference helpOption
 endif

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -11,7 +11,7 @@ endif
 
 let g:colors_name = 'yui'
   
-if has('nvim')
+if (has('nvim'))
 	let g:terminal_color_0 = '#5f503e'
 	let g:terminal_color_1 = '#350303'
 	let g:terminal_color_2 = '#4e4b36'
@@ -29,25 +29,24 @@ if has('nvim')
 	let g:terminal_color_14 = '#4a5054'
 	let g:terminal_color_15 = '#f6f3f0'
 else
-  let g:terminal_ansi_colors = [
-	\'#5f503e',
-	\'#350303',
-	\'#4e4b36',
-	\'#7c4f18',
-	\'#00588f',
-	\'#6132d7',
-	\'#4a5054',
-	\'#f6f3f0',
-	\'#5f503e',
-	\'#350303',
-	\'#4e4b36',
-	\'#7c4f18',
-	\'#00588f',
-	\'#8368e7',
-	\'#4a5054',
-	\'#f6f3f0']
+	let g:terminal_ansi_colors = [
+		\'#5f503e',
+		\'#350303',
+		\'#4e4b36',
+		\'#7c4f18',
+		\'#00588f',
+		\'#6132d7',
+		\'#4a5054',
+		\'#f6f3f0',
+		\'#5f503e',
+		\'#350303',
+		\'#4e4b36',
+		\'#7c4f18',
+		\'#00588f',
+		\'#8368e7',
+		\'#4a5054',
+		\'#f6f3f0']
 endif
-  
 
 " UI & Syntax
 hi Normal guifg=#5f503e ctermfg=239 guibg=#f6f3f0 ctermbg=255
@@ -300,47 +299,47 @@ hi TelescopeSelection guifg=#6132d7 ctermfg=62 guibg=#dcd7f9 ctermbg=189 gui=NON
 
 " yui_folds
 let s:yui_folds_value = get(g:, 'yui_folds', 'fade')
-if s:yui_folds_value ==? 'fade'
+if (s:yui_folds_value ==? 'fade')
 	hi FoldColumn guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
 	hi Folded guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
-elseif s:yui_folds_value ==? 'emphasize'
+elseif (s:yui_folds_value ==? 'emphasize')
 	hi FoldColumn guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
 	hi Folded guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
 endif
 
 " yui_line_numbers
 let s:yui_line_numbers_value = get(g:, 'yui_line_numbers', 'fade')
-if s:yui_line_numbers_value ==? 'fade'
+if (s:yui_line_numbers_value ==? 'fade')
 	hi SignColumn guifg=fg ctermfg=fg guibg=bg ctermbg=bg
 	hi LineNr guifg=#867159 ctermfg=95 guibg=NONE ctermbg=NONE
-elseif s:yui_line_numbers_value ==? 'emphasize'
+elseif (s:yui_line_numbers_value ==? 'emphasize')
 	hi SignColumn guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
 	hi LineNr guifg=#72604b ctermfg=59 guibg=#e0d5ca ctermbg=188
 endif
 
 " yui_emphasized_comments
 let s:yui_emphasized_comments_value = get(g:, 'yui_emphasized_comments', 0)
-if s:yui_emphasized_comments_value ==? 1
+if (s:yui_emphasized_comments_value ==? 1)
 	hi Comment guifg=#ed3f1c ctermfg=202 guibg=NONE ctermbg=NONE gui=italic cterm=italic
-elseif s:yui_emphasized_comments_value ==? 0
+elseif (s:yui_emphasized_comments_value ==? 0)
 	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
 endif
 
 " yui_comments
 let s:yui_comments_value = get(g:, 'yui_comments', 'normal')
-if s:yui_comments_value ==? 'normal'
+if (s:yui_comments_value ==? 'normal')
 	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
-elseif s:yui_comments_value ==? 'fade'
+elseif (s:yui_comments_value ==? 'fade')
 	hi Comment guifg=#72604b ctermfg=59 guibg=NONE ctermbg=NONE gui=italic cterm=italic
-elseif s:yui_comments_value ==? 'emphasize'
+elseif (s:yui_comments_value ==? 'emphasize')
 	hi Comment guifg=#ed3f1c ctermfg=202 guibg=NONE ctermbg=NONE gui=italic cterm=italic
-elseif s:yui_comments_value ==? 'bg'
+elseif (s:yui_comments_value ==? 'bg')
 	hi Comment guifg=fg ctermfg=fg guibg=#ebe4dd ctermbg=254 gui=NONE cterm=NONE
 endif
 
 " yui_lightline
 let s:yui_lightline_value = get(g:, 'yui_lightline', v:false)
-if s:yui_lightline_value ==? v:true
+if (s:yui_lightline_value ==? v:true)
 	let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 	let s:p.visual.left = [
 		\['#dcd7f9', '#6132d7', 189, 62],

--- a/template/theme.lua
+++ b/template/theme.lua
@@ -64,7 +64,7 @@ M.make_hi = function(g)
 	if g.link then
 		table.insert(buf, string.format("hi! link %s %s", g.name, g.link))
 
-		for _, s in ipairs({ "guibg", "guifg", "gui", "guisp", "cterm" }) do
+		for _, s in ipairs { "guibg", "guifg", "gui", "guisp", "cterm" } do
 			assert(g[s] == nil, s .. " must be nil for link but was " .. tostring(g[s]))
 		end
 		goto done
@@ -76,7 +76,10 @@ M.make_hi = function(g)
 		if special_colors[g.guifg] then
 			table.insert(buf, string.format("guifg=%s ctermfg=%s", g.guifg, g.guifg))
 		else
-			table.insert(buf, string.format("guifg=%s ctermfg=%d", g.guifg, colour.hex_to_256(g.guifg)))
+			table.insert(
+				buf,
+				string.format("guifg=%s ctermfg=%d", g.guifg, colour.hex_to_256(g.guifg))
+			)
 		end
 	end
 
@@ -84,7 +87,10 @@ M.make_hi = function(g)
 		if special_colors[g.guibg] then
 			table.insert(buf, string.format("guibg=%s ctermbg=%s", g.guibg, g.guibg))
 		else
-			table.insert(buf, string.format("guibg=%s ctermbg=%d", g.guibg, colour.hex_to_256(g.guibg)))
+			table.insert(
+				buf,
+				string.format("guibg=%s ctermbg=%d", g.guibg, colour.hex_to_256(g.guibg))
+			)
 		end
 	end
 
@@ -319,7 +325,14 @@ M.make_lightline = function(config)
 
 				local line
 				if style ~= nil then
-					line = string.format("\t\\['%s', '%s', %d, %d, '%s'],", fg, bg, fg_code, bg_code, style)
+					line = string.format(
+						"\t\\['%s', '%s', %d, %d, '%s'],",
+						fg,
+						bg,
+						fg_code,
+						bg_code,
+						style
+					)
 				else
 					line = string.format("\t\\['%s', '%s', %d, %d],", fg, bg, fg_code, bg_code)
 				end
@@ -447,7 +460,10 @@ M.make_docs = function(option_groups)
 		-- 1. The string "*yui.txt*"
 		-- 2. As many spaces as necessary to make the line 78 characters long
 		-- 3. The string "A minimal colorscheme for Vim and Neovim"
-		string.format("*yui.txt*%sA minimal colorscheme for Vim and Neovim", string.rep(" ", line_length - 9 - 40)),
+		string.format(
+			"*yui.txt*%sA minimal colorscheme for Vim and Neovim",
+			string.rep(" ", line_length - 9 - 40)
+		),
 		"",
 		"YUI | ユイ",
 		"",
@@ -457,7 +473,10 @@ M.make_docs = function(option_groups)
 	-- insert the word OPTIONS, then as many spaces as necessary, then the
 	-- string '*yui-options*', so that the entire line is 78 characters
 	-- long. This is the format that Vim expects for help tags.
-	table.insert(docs, string.format("OPTIONS%s%s", string.rep(" ", line_length - 8 - 12), "*yui-options*"))
+	table.insert(
+		docs,
+		string.format("OPTIONS%s%s", string.rep(" ", line_length - 8 - 12), "*yui-options*")
+	)
 	table.insert(docs, "")
 
 	for i, group in ipairs(option_groups) do

--- a/template/theme.lua
+++ b/template/theme.lua
@@ -38,6 +38,22 @@ local allowed_attrs = {
 	NONE = true,
 }
 
+-- indent_string indents a string by a given amount. If the string contains
+-- multiple lines, then each line is indented by the given amount. If it's a
+-- single line, then the indent is prepended to the string.
+local function indent_string(s, indent)
+	if s:find("\n") then
+		local indented_lines = {}
+		for line in s:gmatch("[^\n]+") do
+			table.insert(indented_lines, indent .. line)
+		end
+
+		return table.concat(indented_lines, "\n")
+	else
+		return indent .. s
+	end
+end
+
 -- This is a helper function to make a highlight group. It takes a table with the following keys:
 --
 --   name: the name of the highlight group

--- a/template/yui.lua
+++ b/template/yui.lua
@@ -331,7 +331,7 @@ M.groups = {
 
 	{
 		name = "Help Text TS",
-		features = [[has('nvim')]],
+		features = theme.And { "nvim" },
 		groups = {
 			{ name = "@text.literal", link = "helpExample" },
 			{ name = "@text.reference", link = "helpOption" },

--- a/template/yui.lua
+++ b/template/yui.lua
@@ -128,7 +128,13 @@ M.groups = {
 			{ name = "Special", guifg = "fg", guibg = "NONE" },
 			{ name = "SpecialKey", guifg = "fg", guibg = "NONE" },
 			{ name = "SpellBad", link = "DiffDelete" },
-			{ name = "SpellCap", guifg = "NONE", guibg = "NONE", guisp = c.light_red, gui = "undercurl" },
+			{
+				name = "SpellCap",
+				guifg = "NONE",
+				guibg = "NONE",
+				guisp = c.light_red,
+				gui = "undercurl",
+			},
 			{ name = "SpellLocal", guifg = "fg", guibg = "NONE" },
 			{ name = "SpellRare", guifg = "fg", guibg = "NONE" },
 			{ name = "Statement", guifg = "fg", guibg = "NONE", gui = "italic" },
@@ -217,7 +223,13 @@ M.groups = {
 				gui = "undercurl",
 				guisp = c.dark_red,
 			},
-			{ name = "DiagnosticUnderlineHint", guifg = "NONE", guibg = "NONE", gui = "undercurl", guisp = c.black2 },
+			{
+				name = "DiagnosticUnderlineHint",
+				guifg = "NONE",
+				guibg = "NONE",
+				gui = "undercurl",
+				guisp = c.black2,
+			},
 			{
 				name = "DiagnosticUnderlineInfo",
 				guifg = "NONE",
@@ -274,7 +286,12 @@ M.groups = {
 			{ name = "markdownBold", guifg = "NONE", guibg = "NONE", gui = "bold" },
 			{ name = "markdownUrl", guifg = "NONE", guibg = "NONE", gui = "underline" },
 			{ name = "markdownUrl", guifg = "NONE", guibg = "NONE", gui = "underline" },
-			{ name = "markdownHeadingDelimiter", guifg = "NONE", guibg = "NONE", gui = "underline" },
+			{
+				name = "markdownHeadingDelimiter",
+				guifg = "NONE",
+				guibg = "NONE",
+				gui = "underline",
+			},
 			{ name = "mkCode", guifg = "fg", guibg = "NONE" },
 			{ name = "mkdCodeDelimiter", link = "mkCode" },
 			{ name = "markdownItalic", link = "mkItalic" },
@@ -332,8 +349,18 @@ M.groups = {
 	{
 		name = "fugitive",
 		groups = {
-			{ name = "fugitiveStagedSection", guifg = "fg", guibg = "NONE", gui = { "underline", "bold" } },
-			{ name = "fugitiveUnstagedSection", guifg = "fg", guibg = "NONE", gui = { "underline", "bold" } },
+			{
+				name = "fugitiveStagedSection",
+				guifg = "fg",
+				guibg = "NONE",
+				gui = { "underline", "bold" },
+			},
+			{
+				name = "fugitiveUnstagedSection",
+				guifg = "fg",
+				guibg = "NONE",
+				gui = { "underline", "bold" },
+			},
 			{ name = "diffAdded", link = "DiffAdd" },
 			{ name = "diffLine", guifg = "fg", guibg = "NONE", gui = "bold" },
 			{ name = "gitHashAbbrev", guifg = "fg", guibg = "NONE", gui = "underline" },
@@ -422,8 +449,18 @@ M.groups = {
 		name = "Leap",
 		groups = {
 			{ name = "LeapMatch", guifg = c.dark_blue, guibg = c.light_blue, gui = "none" },
-			{ name = "LeapLabelPrimary", guifg = "#ffffff", guibg = c.alternative_accent, gui = "bold" },
-			{ name = "LeapLabelSecondary", guifg = c.light_yellow, guibg = c.dark_yellow, gui = "none" },
+			{
+				name = "LeapLabelPrimary",
+				guifg = "#ffffff",
+				guibg = c.alternative_accent,
+				gui = "bold",
+			},
+			{
+				name = "LeapLabelSecondary",
+				guifg = c.light_yellow,
+				guibg = c.dark_yellow,
+				gui = "none",
+			},
 			{ name = "LeapLabelSelected", guifg = c.dark_red, guibg = c.light_red, gui = "none" },
 		},
 	},
@@ -528,7 +565,12 @@ Whether to emphasize comments]],
 				description = [[
 Emphasize comments]],
 				groups = {
-					{ name = "Comment", guifg = c.alternative_accent, guibg = "NONE", gui = "italic" },
+					{
+						name = "Comment",
+						guifg = c.alternative_accent,
+						guibg = "NONE",
+						gui = "italic",
+					},
 				},
 			},
 			[0] = {
@@ -550,7 +592,12 @@ How comments should be displayed]],
 				description = [[
 Emphasize comments]],
 				groups = {
-					{ name = "Comment", guifg = c.alternative_accent, guibg = "NONE", gui = "italic" },
+					{
+						name = "Comment",
+						guifg = c.alternative_accent,
+						guibg = "NONE",
+						gui = "italic",
+					},
 				},
 			},
 			["'fade'"] = {


### PR DESCRIPTION
This PR first adds a stylua file and applies those formatting rules to the codebase.

Then, it adds some combinators for conditionals. There are a few places in the
theme where conditionals are necessary:
- the different branches of option groups
- if HL groups are only available in Neovim but not Vim (or vice versa)
- to determine which terminal color syntax to use, since Neovim and Vim use a different API

All three cases were handled separately, and in an ad-hoc fashion. This resulted in duplication,
and meant that every case was special. Adding any new conditional meant thinking about how to
implement it, what API to use, and so on.

In the end I considered just going back to plain Vim script but that would have complicated things
quite a bit. First, I don't know Vim script. And what would I have done about the current Lua code
for automatically picking terminal color codes?

So I decided to double down on the Lua-to-Vim approach. It's also more fun.

I ended up adding combinators, since I'm a bit more familiar with this approach from Haskell. I
also tried to take some inspiration by the elegance and simplicity of LISP macros. Meaning, code
is data and you can traverse and modify these combinators like any other data structure.

I'd like to also add more combinators in the future for other Vim primitives, such as highlight
groups.
