### PR TITLE
Improve base syntax colors; different SpecialKey for Vim/Neovim;

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,35 @@ You can refer to the color of another HL group through `d:get("Normal", "guifg")
 You can also go a step further and modify the color that you are copying. Replace  `d:get("Normal", "guifg")` with  `d:call("Normal", "guifg", colour.lighten, 5)`. This makes the color lighter. Supported values for `colour.lighten` are positive and negative integers and `-aa`, `-aaa`, `aa` and  `aaa`. These refer to pre-determined contrast ratios of the W3C.
 
 That's it!
+
+## Handling LSP & TS Colors
+
+### Guidelines
+
+- Prefer general over specific; choose `@lsp.typemod.function.declaration` over `@lsp.typemod.function.declaration.lua`
+- When overriding colors, link LSP and TS groups when possible
+
+### Details
+
+There are two layers of highlight groups:
+- The base colors from Vim that are mentioned in `:h syntax.txt`, such as `Title`
+- LSP colors (all the `@lsp.*` tokens), Treesitter colors (such as `@function`) and more specific Vim colors (such as `luaFunc`)
+
+Changing the base colors should be done sparingly, since it affects a lot of languages and it's impossible to properly anticipate the impact of a change.
+
+The other layer is already linked to the first by default. If you change a color in one of the groups, please consider if the other groups should be linked to the first one. Here's an example: say you want to make function declarations underlined. Open a file and check the current HL groups with `:Inspect`. You might discover that this is `@function` in TS and `@lsp.typemod.declaration.function` in LSP. Here it makes sense to treat one of them as the source of truth and link the other (s) to that. So make the LSP color the source of truth and link the other color to it like this:
+
+```lua
+{
+	["@function"] = hl {
+		"@function",
+		guifg = d:get("@lsp.typemod.function.declaration", "guifg"),
+		guibg = d:get("@lsp.typemod.function.declaration", "guibg"),
+		gui = d:get("@lsp.typemod.function.declaration", "gui"),
+	}
+}
+```
+
+The LSP and TS groups are often language specific but you can just remove the last `.lua` part in `@lsp.typemod.function.declaration.lua` and make the declaration more general.
+
+Ideally also locate some of the Vim colors and link them as well. Unfortunately there's no real middle ground here. There's the base syntax which doesn't include anything for function declarations and then there's a myriad of language specific rules. Update as many as you have at hand.

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -28,8 +28,40 @@ hi DiffDelete guifg=#A50303 ctermfg=124 guibg=#ffebeb ctermbg=255 gui=NONE cterm
 hi DiffText guifg=#1E5571 ctermfg=23 guibg=#efeff9 ctermbg=255
 hi Directory guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi ErrorMsg guifg=#A50303 ctermfg=124 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi Constant guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi! link String Constant
+hi! link Character Constant
+hi! link Number Constant
+hi! link Boolean Constant
+hi! link Float Constant
 hi Identifier guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi! link Function Identifier
+hi Statement guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi Conditional guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi Repeat guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi Label guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
+hi! link Operator Statement
+hi! link Keyword Statement
+hi! link Exception Statement
+hi PreProc guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi! link Include PreProc
+hi! link Define PreProc
+hi! link Macro PreProc
+hi! link PreCondit PreProc
+hi Type guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi! link StorageClass Type
+hi! link Structure Type
+hi Typedef guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
+hi Special guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi! link SpecialChar Special
+hi! link Tag Special
+hi! link Delimiter Special
+hi! link SpecialComment Special
+hi! link Debug Special
+hi Underlined guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
 hi Ignore guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Error guifg=#A50303 ctermfg=124 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi! link Todo DiffChange
 hi MatchParen guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 hi ModeMsg guifg=#1E5571 ctermfg=23 guibg=#efeff9 ctermbg=255 gui=NONE cterm=NONE
 hi MoreMsg guifg=#1E5571 ctermfg=23 guibg=#efeff9 ctermbg=255 gui=NONE cterm=NONE
@@ -41,52 +73,20 @@ hi! link TabLineFill TabLine
 hi Search guifg=#2D199F ctermfg=19 guibg=#c3c3ea ctermbg=252 gui=NONE cterm=NONE
 hi CurSearch guifg=#241384 ctermfg=18 guibg=#8a8ae1 ctermbg=104 gui=bold cterm=bold
 hi IncSearch guifg=#27158e ctermfg=18 guibg=#8f8fe2 ctermbg=104 gui=bold cterm=bold
-hi SpecialKey guifg=#605001 ctermfg=58 guibg=#fff1c9 ctermbg=230
 hi! link SpellCap SpellBad
 hi! link SpellLocal SpellBad
 hi! link SpellRare SpellBad
-hi Type guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=italic cterm=italic
 hi! link Tooltip Pmenu
 hi! link MsgSeparator VertSplit
 hi! link EndOfBuffer NonText
 hi! link QuickFixLine Search
 hi! link WildMenu IncSearch
-hi! link Boolean Constant
-hi! link Character Constant
-hi Conditional guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi! link Define PreProc
-hi! link Debug Special
-hi! link Delimiter Special
-hi! link Float Number
-hi! link Function Identifier
-hi! link Include PreProc
-hi! link Macro PreProc
-hi! link Number Constant
-hi! link PreCondit PreProc
-hi! link SpecialChar Special
-hi! link SpecialComment Special
-hi! link StorageClass Type
-hi String guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
-hi! link Structure Type
-hi! link Tag Special
-hi! link Typedef Type
 hi! link Substitute IncSearch
-hi Operator guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi Repeat guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi Constant guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 hi jsParensError guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi! link Todo DiffChange
-hi Error guifg=#A50303 ctermfg=124 guibg=bg ctermbg=bg gui=bold cterm=bold
-hi Exception guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi Keyword guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi Label guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi Special guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi SpellBad guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE guisp=#A50303 gui=undercurl cterm=undercurl
-hi Statement guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
-hi Underlined guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
 hi! link VertSplit NonText
 hi! link Menu Pmenu
-hi Title guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
+hi Title guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold,underline cterm=bold,underline
 hi! link NormalFloat Pmenu
 hi FloatTitle guifg=fg ctermfg=fg guibg=#ffffff ctermbg=231 gui=underline,bold cterm=underline,bold
 hi FloatBorder guifg=#ffffff ctermfg=231 guibg=#ffffff ctermbg=231
@@ -106,7 +106,6 @@ hi PmenuKindSel guifg=#2D199F ctermfg=19 guibg=#c3c3ea ctermbg=252 gui=bold cter
 hi PmenuExtra guifg=#656565 ctermfg=241 guibg=NONE ctermbg=NONE
 hi PmenuSbar guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE
 hi PmenuThumb guifg=NONE ctermfg=NONE guibg=#e2e2e2 ctermbg=254
-hi PreProc guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi Question guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi Visual guifg=#2D199F ctermfg=19 guibg=#c3c3ea ctermbg=252 gui=NONE cterm=NONE
 hi VisualNOS guifg=#371fbb ctermfg=55 guibg=#d2d2ef ctermbg=189
@@ -137,17 +136,6 @@ hi vimHiGroup guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi vimHiCTerm guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi vimHiCTermFgBg guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi vimHiGuiFgBg guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi luaFuncKeyword guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi luaFuncName guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold
-hi! link luaRepeat Repeat
-hi! link luaCond Conditional
-hi luaParens guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi luaSpecialValue guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
-hi luaLocal guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi luaGotoLabel guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold,underline cterm=bold,underline
-hi luaBraces guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi luaStatement guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-hi! link luaBuiltIn luaSpecialValue
 hi htmlTagName guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi typescriptParens guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
 hi! link typescriptFuncName luaFuncName
@@ -229,6 +217,7 @@ hi! link WhichKeyFloating Pmenu
 hi! link TelescopeMatching CurSearch
 hi! link TelescopeSelection Search
 if has('nvim')
+	hi SpecialKey guifg=#605001 ctermfg=58 guibg=#fff1c9 ctermbg=230
 	let g:terminal_color_0 = '#504944'
 	let g:terminal_color_1 = '#A50303'
 	let g:terminal_color_2 = '#38551E'
@@ -245,21 +234,18 @@ if has('nvim')
 	let g:terminal_color_13 = '#4126d8'
 	let g:terminal_color_14 = '#377166'
 	let g:terminal_color_15 = '#e4dbdb'
-	hi! link @text.literal helpExample
-	hi! link @text.reference helpOption
-	hi @tag.tsx guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE
-	hi! link @function.lua luaFuncName
-	hi! link @keyword.function.lua luaFuncKeyword
-	hi! link @repeat.lua luaRepeat
-	hi! link @conditional.lua luaCond
-	hi! link @function.builtin.lua luaSpecialValue
-	hi! link @variable.builtin.lua luaSpecialValue
-	hi! link @method.lua @function.lua
-	hi @label.lua guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold,underline cterm=bold,underline
-	hi! link @lsp.typemod.method.declaration.lua luaFuncName
+
+	hi @text.literal guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+	hi @function guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
+	hi @function.call guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+	hi @function.builtin guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+
+	hi @lsp.typemod.function.defaultLibrary guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+	hi @lsp.typemod.function.declaration guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline cterm=underline
 else
 	hi! link StatusLineTerm StatusLine
 	hi! link StatusLineTermNC StatusLineNC
+	hi! link SpecialKey Whitespace
 	let g:terminal_ansi_colors = [
 		\ '#504944',
 		\ '#A50303',

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -1,7 +1,3 @@
--- TODO: from :h lsp add highlights for the @lsp groups and use them as the source of truth
---       change hl groups like luaFuncKeyword to link to @lsp groups and do the same for
---       TS groups. The old school Vim HL groups are then mainly general fallbacks
-
 local colour = require("colour")
 local Theme = require("theme")
 local Nvim = require("nvim")
@@ -279,8 +275,57 @@ nvim:add_hlgroups {
 	hl { "DiffText", guifg = p.blue, guibg = colour.lighten(p.blue, "AAA") },
 	hl { "Directory", guifg = "fg", guibg = "NONE" },
 	hl { "ErrorMsg", guifg = d:get("DiffDelete", "guifg"), guibg = "NONE", gui = "bold" },
+
+	-- ===================================
+	-- = Base Vim Language Syntax Groups =
+	-- ===================================
+	-- These are the groups mentioned in :h syntax.txt under
+	-- "NAMING CONVENTIONS". A lot of other groups are linked to
+	-- these, such as some Treesitter and LSP groups.
+	hl { "Constant", guifg = "fg", guibg = "NONE", gui = "bold" },
+	hl { "String", link = "Constant" },
+	hl { "Character", link = "Constant" },
+	hl { "Number", link = "Constant" },
+	hl { "Boolean", link = "Constant" },
+	hl { "Float", link = "Constant" },
+
 	hl { "Identifier", guifg = "fg", guibg = "NONE" },
+	hl { "Function", link = "Identifier" },
+
+	hl { "Statement", guifg = "fg", guibg = "NONE", gui = "NONE" },
+	hl { "Conditional", guifg = "fg", guibg = "NONE", gui = "italic" },
+	hl { "Repeat", guifg = "fg", guibg = "NONE", gui = "italic" },
+	hl { "Label", guifg = "fg", guibg = "NONE", gui = "underline" },
+	hl { "Operator", link = "Statement" },
+	hl { "Keyword", link = "Statement" },
+	hl { "Exception", link = "Statement" },
+
+	hl { "PreProc", guifg = "fg", guibg = "NONE", gui = "bold" },
+	hl { "Include", link = "PreProc" },
+	hl { "Define", link = "PreProc" },
+	hl { "Macro", link = "PreProc" },
+	hl { "PreCondit", link = "PreProc" },
+
+	hl { "Type", guifg = "NONE", guibg = "NONE", gui = "NONE" },
+	hl { "StorageClass", link = "Type" },
+	hl { "Structure", link = "Type" },
+	hl { "Typedef", guifg = "fg", guibg = "NONE", gui = { "italic" } },
+
+	hl { "Special", guifg = "fg", guibg = "NONE", gui = { "NONE" } },
+	hl { "SpecialChar", link = "Special" },
+	hl { "Tag", link = "Special" },
+	hl { "Delimiter", link = "Special" },
+	hl { "SpecialComment", link = "Special" },
+	hl { "Debug", link = "Special" },
+
+	hl { "Underlined", guifg = "fg", guibg = "NONE", gui = "underline" },
+
 	hl { "Ignore", guifg = "fg", guibg = "NONE" },
+
+	hl { "Error", guifg = p.red, guibg = "NONE", gui = "bold" },
+
+	hl { "Todo", link = "DiffChange" },
+
 	hl { "MatchParen", guibg = "NONE", guifg = "fg", gui = "bold" },
 	hl { "ModeMsg", guifg = d:get("DiffText", "guifg"), guibg = d:get("DiffText", "guibg"), gui = "NONE" },
 	hl { "MoreMsg", guifg = d:get("DiffText", "guifg"), guibg = d:get("DiffText", "guibg"), gui = "NONE" },
@@ -302,52 +347,20 @@ nvim:add_hlgroups {
 		guibg = d:call("IncSearch", "guifg", colour.lighten, "AA"),
 		gui = "bold",
 	},
-	hl { "SpecialKey", guifg = p.yellow, guibg = colour.lighten(p.yellow, "AAA") },
 	hl { "SpellCap", link = "SpellBad" },
 	hl { "SpellLocal", link = "SpellBad" },
 	hl { "SpellRare", link = "SpellBad" },
-	hl { "Type", guifg = "NONE", guibg = "NONE", gui = "italic" },
 	hl { "Tooltip", link = "Pmenu" },
 	hl { "MsgSeparator", link = "VertSplit" },
 	hl { "EndOfBuffer", link = "NonText" },
 	hl { "QuickFixLine", link = "Search" },
 	hl { "WildMenu", link = "IncSearch" },
-	hl { "Boolean", link = "Constant" },
-	hl { "Character", link = "Constant" },
-	hl { "Conditional", guifg = "fg", guibg = "NONE", gui = "NONE" },
-	hl { "Define", link = "PreProc" },
-	hl { "Debug", link = "Special" },
-	hl { "Delimiter", link = "Special" },
-	hl { "Float", link = "Number" },
-	hl { "Function", link = "Identifier" },
-	hl { "Include", link = "PreProc" },
-	hl { "Macro", link = "PreProc" },
-	hl { "Number", link = "Constant" },
-	hl { "PreCondit", link = "PreProc" },
-	hl { "SpecialChar", link = "Special" },
-	hl { "SpecialComment", link = "Special" },
-	hl { "StorageClass", link = "Type" },
-	hl { "String", guifg = "fg", guibg = "NONE", gui = "bold" },
-	hl { "Structure", link = "Type" },
-	hl { "Tag", link = "Special" },
-	hl { "Typedef", link = "Type" },
 	hl { "Substitute", link = "IncSearch" },
-	hl { "Operator", guifg = "fg", guibg = "NONE" },
-	hl { "Repeat", guifg = "fg", guibg = "NONE" },
-	hl { "Constant", guifg = "fg", guibg = "NONE", gui = "bold" },
 	hl { "jsParensError", guifg = "fg", guibg = "NONE" },
-	hl { "Todo", link = "DiffChange" },
-	hl { "Error", guifg = p.red, guibg = "bg", gui = "bold" },
-	hl { "Exception", guifg = "fg", guibg = "NONE" },
-	hl { "Keyword", guifg = "fg", guibg = "NONE" },
-	hl { "Label", guifg = "fg", guibg = "NONE" },
-	hl { "Special", guifg = "fg", guibg = "NONE" },
 	hl { "SpellBad", guifg = "fg", guibg = "NONE", gui = "undercurl", guisp = p.red },
-	hl { "Statement", guifg = "fg", guibg = "NONE", gui = "italic" },
-	hl { "Underlined", guifg = "fg", guibg = "NONE", gui = "underline" },
 	hl { "VertSplit", link = "NonText" },
 	hl { "Menu", link = "Pmenu" },
-	hl { "Title", guifg = "fg", guibg = "NONE" },
+	hl { "Title", guifg = "fg", guibg = "NONE", gui = { "bold", "underline" } },
 	hl { "NormalFloat", link = "Pmenu" },
 	hl { "FloatTitle", guifg = "fg", guibg = d:get("Pmenu", "guibg"), gui = { "underline", "bold" } },
 	hl { "FloatBorder", guifg = d:get("Pmenu", "guibg"), guibg = d:get("Pmenu", "guibg") },
@@ -393,7 +406,6 @@ nvim:add_hlgroups {
 	hl { "PmenuExtra", guifg = d:call("Pmenu", "guifg", colour.lighten, 5), guibg = "NONE" },
 	hl { "PmenuSbar", guifg = "NONE", guibg = "NONE" },
 	hl { "PmenuThumb", guifg = "NONE", guibg = d:call("Pmenu", "guibg", colour.lighten, -10) },
-	hl { "PreProc", guifg = "fg", guibg = "NONE" },
 	hl { "Question", guifg = "fg", guibg = "NONE" },
 	hl { "Visual", guifg = d:get("Search", "guifg"), guibg = d:get("Search", "guibg"), gui = "NONE" },
 	hl {
@@ -428,17 +440,6 @@ nvim:add_hlgroups {
 	hl { "vimHiCTerm", guifg = "fg", guibg = "NONE" },
 	hl { "vimHiCTermFgBg", guifg = "fg", guibg = "NONE" },
 	hl { "vimHiGuiFgBg", guifg = "fg", guibg = "NONE" },
-	hl { "luaFuncKeyword", guifg = "fg", guibg = "NONE", gui = "NONE" },
-	hl { "luaFuncName", guifg = "fg", guibg = "NONE", gui = { "underline", "bold" } },
-	hl { "luaRepeat", link = "Repeat" },
-	hl { "luaCond", link = "Conditional" },
-	hl { "luaParens", guifg = "fg", guibg = "NONE", gui = "NONE" },
-	hl { "luaSpecialValue", guifg = "fg", guibg = "NONE", gui = "bold" },
-	hl { "luaLocal", guifg = "fg", guibg = "NONE" },
-	hl { "luaGotoLabel", guifg = "fg", guibg = "NONE", gui = d:get("@label.lua", "gui") },
-	hl { "luaBraces", guifg = "fg", guibg = "NONE" },
-	hl { "luaStatement", guifg = "fg", guibg = "NONE" },
-	hl { "luaBuiltIn", link = "luaSpecialValue" },
 	hl { "htmlTagName", guifg = "fg", guibg = "NONE", gui = "NONE" },
 	hl { "typescriptParens", guifg = "fg", guibg = "NONE" },
 	hl { "typescriptFuncName", link = "luaFuncName" },
@@ -551,18 +552,14 @@ if has('nvim')
 	let g:terminal_color_13 = '${term_bright_purple}'
 	let g:terminal_color_14 = '${term_bright_cyan}'
 	let g:terminal_color_15 = '${term_bright_white}'
-	${@text_literal}
-	${@text_reference}
-	${@tag.tsx}
-	${@function.lua}
-	${@keyword.function.lua}
-	${@repeat.lua}
-	${@conditional.lua}
-	${@function.builtin.lua}
-	${@variable.builtin.lua}
-	${@method.lua}
-	${@label.lua}
-	${@lsp.typemod.method.declaration.lua}
+
+	${@text.literal}
+	${@function}
+	${@function.call}
+	${@function.builtin}
+
+	${@lsp.typemod.function.defaultLibrary}
+	${@lsp.typemod.function.declaration}
 else
 	${statusline_term}
 	${statusline_term_nc}
@@ -602,20 +599,36 @@ endif
 		term_bright_purple = colour.lighten(p.purple, 10),
 		term_bright_cyan = colour.lighten(p.cyan, 10),
 		term_bright_white = d:call("term_bright_black", colour.lighten, "aa"),
-		["@text_literal"] = hl { "@text.literal", link = "helpExample" },
-		["@text_reference"] = hl { "@text.reference", link = "helpOption" },
-		["@tag.tsx"] = hl { "@tag.tsx", guifg = "fg", guibg = "NONE" },
-		["@function.lua"] = hl { "@function.lua", link = "luaFuncName" },
-		["@keyword.function.lua"] = hl { "@keyword.function.lua", link = "luaFuncKeyword" },
-		["@repeat.lua"] = hl { "@repeat.lua", link = "luaRepeat" },
-		["@conditional.lua"] = hl { "@conditional.lua", link = "luaCond" },
-		["@function.builtin.lua"] = hl { "@function.builtin.lua", link = "luaSpecialValue" },
-		["@variable.builtin.lua"] = hl { "@variable.builtin.lua", link = "luaSpecialValue" },
-		["@method.lua"] = hl { "@method.lua", link = "@function.lua" },
-		["@label.lua"] = hl { "@label.lua", guifg = "fg", guibg = "NONE", gui = { "bold", "underline" } },
-		["@lsp.typemod.method.declaration.lua"] = hl { "@lsp.typemod.method.declaration.lua", link = "luaFuncName" },
 		statusline_term = hl { "StatusLineTerm", link = "StatusLine" },
 		statusline_term_nc = hl { "StatusLineTermNC", link = "StatusLineNC" },
+
+		["@text.literal"] = hl { "@text.literal", guifg = "fg", guibg = "NONE", gui = "NONE" },
+		["@function.call"] = hl { "@function.call", guifg = "fg", guibg = "NONE", gui = "NONE" },
+		["@function"] = hl {
+			"@function",
+			guifg = d:get("@lsp.typemod.function.declaration", "guifg"),
+			guibg = d:get("@lsp.typemod.function.declaration", "guibg"),
+			gui = d:get("@lsp.typemod.function.declaration", "gui"),
+		},
+		["@function.builtin"] = hl {
+			"@function.builtin",
+			guifg = d:get("@lsp.typemod.function.defaultLibrary", "guifg"),
+			guibg = d:get("@lsp.typemod.function.defaultLibrary", "guibg"),
+			gui = d:get("@lsp.typemod.function.defaultLibrary", "gui"),
+		},
+
+		["@lsp.typemod.function.defaultLibrary"] = hl {
+			"@lsp.typemod.function.defaultLibrary",
+			guifg = "fg",
+			guibg = "NONE",
+			gui = { "bold" },
+		},
+		["@lsp.typemod.function.declaration"] = hl {
+			"@lsp.typemod.function.declaration",
+			guifg = "fg",
+			guibg = "NONE",
+			gui = { "underline" },
+		},
 	}
 )
 

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -536,6 +536,7 @@ nvim:add_hlgroups {
 nvim:interpolate(
 	[[
 if has('nvim')
+	${specialkey_nvim}
 	let g:terminal_color_0 = '${term_black}'
 	let g:terminal_color_1 = '${term_red}'
 	let g:terminal_color_2 = '${term_green}'
@@ -563,6 +564,7 @@ if has('nvim')
 else
 	${statusline_term}
 	${statusline_term_nc}
+	${specialkey_vim}
 	let g:terminal_ansi_colors = [
 		\ '${term_black}',
 		\ '${term_red}',
@@ -601,6 +603,9 @@ endif
 		term_bright_white = d:call("term_bright_black", colour.lighten, "aa"),
 		statusline_term = hl { "StatusLineTerm", link = "StatusLine" },
 		statusline_term_nc = hl { "StatusLineTermNC", link = "StatusLineNC" },
+		-- SpecialKey is not listchars whitespace in Neovim but it is in Vim!
+		specialkey_nvim = hl { "SpecialKey", guifg = p.yellow, guibg = colour.lighten(p.yellow, "AAA") },
+		specialkey_vim = hl { "SpecialKey", link = "Whitespace" },
 
 		["@text.literal"] = hl { "@text.literal", guifg = "fg", guibg = "NONE", gui = "NONE" },
 		["@function.call"] = hl { "@function.call", guifg = "fg", guibg = "NONE", gui = "NONE" },


### PR DESCRIPTION
- Improve base syntax HL groups and LSP & TS handling
    * Remove some unnecessary overrides, since the defaults can be improved
      instead
    * When overriding, try to link LSP to TS or the other way around
    * Add this info as a guideline to CONTRIBUTING
- Different SpecialKey for Vim and Neovim
    * In Vim it's used for listchars, in Neovim it's not so we can't use the same HL group for both
