### PR TITLE
Add .toml version of Alacritty colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: colors/yui.vim doc/yui.txt autoload/lightline/colorscheme/yui.vim alacritty/yui.yml fish/yui.fish
+all: colors/yui.vim doc/yui.txt autoload/lightline/colorscheme/yui.vim alacritty/yui.yml alacritty/yui.toml fish/yui.fish
 
 lua_path = src/?.lua
 lua_files = src/*.lua
@@ -11,6 +11,10 @@ colors/yui.vim: $(lua_files)
 alacritty/yui.yml: $(lua_files)
 	@mkdir -p alacritty
 	LUA_PATH="$(lua_path)" lua -e 'print(require("yui").alacritty)' > $@
+
+alacritty/yui.toml: $(lua_files)
+	@mkdir -p alacritty
+	LUA_PATH="$(lua_path)" lua -e 'print(require("yui").alacritty_toml)' > $@
 
 fish/yui.fish: $(lua_files)
 	@mkdir -p fish

--- a/alacritty/yui.toml
+++ b/alacritty/yui.toml
@@ -1,0 +1,63 @@
+	[colors]
+	[colors.primary]
+	foreground = "#504944"
+	background = "#f1eded"
+	dim_foreground = "#443e39"
+	bright_foreground = "#5d554f"
+	[colors.cursor]
+	text = "#504944"
+	cursor = "#d1882f"
+	[colors.vi_mode_cursor]
+	text = "#504944"
+	cursor = "#bf7c2a"
+	[colors.search]
+	[colors.search.matches]
+	foreground = "#522F86"
+	background = "#d7d6f1"
+	[colors.search.focused_match]
+	foreground = "#4a2a7a"
+	background = "#a89edf"
+	[colors.hints]
+	[colors.hints.start]
+	foreground = "#bcbee8"
+	background = "#1E5571"
+	[colors.hints.end]
+	foreground = "#1E5571"
+	background = "#bcbee8"
+	[colors.line_indicator]
+	foreground = "#423333"
+	background = "#d2c3c3"
+	[colors.footer_bar]
+	foreground = "#423333"
+	background = "#d2c3c3"
+	[colors.selection]
+	text = "#522F86"
+	background = "#d7d6f1"
+	[colors.normal]
+	black = "#504944"
+	red = "#d30505"
+	green = "#5e8a36"
+	yellow = "#bba53b"
+	blue = "#296e92"
+	magenta = "#60389b"
+	cyan = "#377166"
+	white = "#bfb8b3"
+	[colors.bright]
+	black = "#69605a"
+	red = "#d30505"
+	green = "#72a643"
+	yellow = "#d9c046"
+	blue = "#296e92"
+	magenta = "#6e41b1"
+	cyan = "#377166"
+	white = "#e4dbdb"
+	[colors.dim]
+	black = "#38332f"
+	red = "#a50303"
+	green = "#4b6f2a"
+	yellow = "#9d8b30"
+	blue = "#1e5571"
+	magenta = "#452771"
+	cyan = "#29574e"
+	white = "#a39d99"
+

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,29 @@
           inherit system;
         };
 
+        alacrittyToml = pkgs.stdenv.mkDerivation rec {
+          name = "yui-alacritty";
+          buildInputs = with pkgs; [
+            lua54Packages.lua
+          ];
+          buildPhase = ''
+            make alacritty/yui.toml
+            rm -r src Makefile flake.nix flake.lock README.md CONTRIBUTING.md LICENSE.txt
+          '';
+          src = pkgs.lib.cleanSourceWith {
+            filter = path: type:
+              !(pkgs.lib.hasInfix "screenshots" path)
+              && !(pkgs.lib.hasInfix "colors/" path)
+              && !(pkgs.lib.hasInfix "autoload/" path)
+              && !(pkgs.lib.hasInfix "doc/" path);
+            src = ./.;
+          };
+          installPhase = ''
+            mkdir -p $out
+            cp alacritty/yui.toml $out/yui.toml
+          '';
+        };
+
         alacritty = pkgs.stdenv.mkDerivation rec {
           name = "yui-alacritty";
           buildInputs = with pkgs; [
@@ -65,6 +88,7 @@
         packages = flake-utils.lib.flattenTree {
           nvim = nvim;
           alacritty = alacritty;
+          alacrittyToml = alacrittyToml;
         };
 
         defaultPackage = packages.yui;

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -102,6 +102,55 @@ let g:lightline#colorscheme#yui#palette = lightline#colorscheme#fill(s:p)
 	}
 )
 
+local alacritty_colors = {
+	alac_primary_fg = d:get("Normal", "guifg"),
+	alac_primary_bg = d:get("Normal", "guibg"),
+	alac_primary_dim_fg = d:call("Normal", "guifg", colour.lighten, -5),
+	alac_primary_bright_fg = d:call("Normal", "guifg", colour.lighten, 5),
+	alac_cursor_fg = p.black,
+	alac_cursor_bg = d:call("alac_vi_cursor_bg", colour.lighten, 5),
+	alac_vi_cursor_fg = p.black,
+	alac_vi_cursor_bg = p.orange,
+	alac_matches_fg = d:get("Search", "guifg"),
+	alac_matches_bg = d:get("Search", "guibg"),
+	alac_focused_match_fg = d:get("IncSearch", "guifg"),
+	alac_focused_match_bg = d:get("IncSearch", "guibg"),
+	alac_first_hint_char_fg = d:get("DiagnosticInfo", "guibg"),
+	alac_first_hint_char_bg = d:get("DiagnosticInfo", "guifg"),
+	alac_chars_after_first_hint_fg = d:get("DiagnosticInfo", "guifg"),
+	alac_chars_after_first_hint_bg = d:get("DiagnosticInfo", "guibg"),
+	alac_line_indicator_fg = d:get("StatusLine", "guifg"),
+	alac_line_indicator_bg = d:get("StatusLine", "guibg"),
+	alac_footer_fg = d:get("StatusLine", "guifg"),
+	alac_footer_bg = d:get("StatusLine", "guibg"),
+	alac_selection_fg = d:get("Visual", "guifg"),
+	alac_selection_bg = d:get("Visual", "guibg"),
+	alac_normal_black = d:get("term_black"),
+	alac_normal_red = d:get("term_red"),
+	alac_normal_green = d:get("term_green"),
+	alac_normal_yellow = d:get("term_yellow"),
+	alac_normal_blue = d:get("term_blue"),
+	alac_normal_magenta = d:get("term_purple"),
+	alac_normal_cyan = d:get("term_cyan"),
+	alac_normal_white = d:get("term_white"),
+	alac_bright_black = d:get("term_bright_black"),
+	alac_bright_red = d:get("term_bright_red"),
+	alac_bright_green = d:get("term_bright_green"),
+	alac_bright_yellow = d:get("term_bright_yellow"),
+	alac_bright_blue = d:get("term_bright_blue"),
+	alac_bright_magenta = d:get("term_bright_purple"),
+	alac_bright_cyan = d:get("term_bright_cyan"),
+	alac_bright_white = d:get("term_bright_white"),
+	alac_dim_black = d:call("term_black", colour.lighten, -10),
+	alac_dim_red = d:call("term_red", colour.lighten, -10),
+	alac_dim_green = d:call("term_green", colour.lighten, -10),
+	alac_dim_yellow = d:call("term_yellow", colour.lighten, -10),
+	alac_dim_blue = d:call("term_blue", colour.lighten, -10),
+	alac_dim_magenta = d:call("term_purple", colour.lighten, -10),
+	alac_dim_cyan = d:call("term_cyan", colour.lighten, -10),
+	alac_dim_white = d:call("term_white", colour.lighten, -10),
+}
+
 alacritty:interpolate(
 	[[
 { 
@@ -185,54 +234,82 @@ alacritty:interpolate(
 	}
 }
 ]],
-	{
-		alac_primary_fg = d:get("Normal", "guifg"),
-		alac_primary_bg = d:get("Normal", "guibg"),
-		alac_primary_dim_fg = d:call("Normal", "guifg", colour.lighten, -5),
-		alac_primary_bright_fg = d:call("Normal", "guifg", colour.lighten, 5),
-		alac_cursor_fg = p.black,
-		alac_cursor_bg = d:call("alac_vi_cursor_bg", colour.lighten, 5),
-		alac_vi_cursor_fg = p.black,
-		alac_vi_cursor_bg = p.orange,
-		alac_matches_fg = d:get("Search", "guifg"),
-		alac_matches_bg = d:get("Search", "guibg"),
-		alac_focused_match_fg = d:get("IncSearch", "guifg"),
-		alac_focused_match_bg = d:get("IncSearch", "guibg"),
-		alac_first_hint_char_fg = d:get("DiagnosticInfo", "guibg"),
-		alac_first_hint_char_bg = d:get("DiagnosticInfo", "guifg"),
-		alac_chars_after_first_hint_fg = d:get("DiagnosticInfo", "guifg"),
-		alac_chars_after_first_hint_bg = d:get("DiagnosticInfo", "guibg"),
-		alac_line_indicator_fg = d:get("StatusLine", "guifg"),
-		alac_line_indicator_bg = d:get("StatusLine", "guibg"),
-		alac_footer_fg = d:get("StatusLine", "guifg"),
-		alac_footer_bg = d:get("StatusLine", "guibg"),
-		alac_selection_fg = d:get("Visual", "guifg"),
-		alac_selection_bg = d:get("Visual", "guibg"),
-		alac_normal_black = d:get("term_black"),
-		alac_normal_red = d:get("term_red"),
-		alac_normal_green = d:get("term_green"),
-		alac_normal_yellow = d:get("term_yellow"),
-		alac_normal_blue = d:get("term_blue"),
-		alac_normal_magenta = d:get("term_purple"),
-		alac_normal_cyan = d:get("term_cyan"),
-		alac_normal_white = d:get("term_white"),
-		alac_bright_black = d:get("term_bright_black"),
-		alac_bright_red = d:get("term_bright_red"),
-		alac_bright_green = d:get("term_bright_green"),
-		alac_bright_yellow = d:get("term_bright_yellow"),
-		alac_bright_blue = d:get("term_bright_blue"),
-		alac_bright_magenta = d:get("term_bright_purple"),
-		alac_bright_cyan = d:get("term_bright_cyan"),
-		alac_bright_white = d:get("term_bright_white"),
-		alac_dim_black = d:call("term_black", colour.lighten, -10),
-		alac_dim_red = d:call("term_red", colour.lighten, -10),
-		alac_dim_green = d:call("term_green", colour.lighten, -10),
-		alac_dim_yellow = d:call("term_yellow", colour.lighten, -10),
-		alac_dim_blue = d:call("term_blue", colour.lighten, -10),
-		alac_dim_magenta = d:call("term_purple", colour.lighten, -10),
-		alac_dim_cyan = d:call("term_cyan", colour.lighten, -10),
-		alac_dim_white = d:call("term_white", colour.lighten, -10),
-	}
+	alacritty_colors
+)
+
+local alacritty_toml_colors = {}
+for k, v in pairs(alacritty_colors) do
+	local prefixed = k:gsub("alac_", "alac_toml_")
+	alacritty_toml_colors[prefixed] = v
+end
+
+local alacritty_toml = Theme:new(d)
+alacritty_toml:interpolate(
+	[[
+	[colors]
+	[colors.primary]
+	foreground = "${alac_toml_primary_fg}"
+	background = "${alac_toml_primary_bg}"
+	dim_foreground = "${alac_toml_primary_dim_fg}"
+	bright_foreground = "${alac_toml_primary_bright_fg}"
+	[colors.cursor]
+	text = "${alac_toml_cursor_fg}"
+	cursor = "${alac_toml_cursor_bg}"
+	[colors.vi_mode_cursor]
+	text = "${alac_toml_vi_cursor_fg}"
+	cursor = "${alac_toml_vi_cursor_bg}"
+	[colors.search]
+	[colors.search.matches]
+	foreground = "${alac_toml_matches_fg}"
+	background = "${alac_toml_matches_bg}"
+	[colors.search.focused_match]
+	foreground = "${alac_toml_focused_match_fg}"
+	background = "${alac_toml_focused_match_bg}"
+	[colors.hints]
+	[colors.hints.start]
+	foreground = "${alac_toml_first_hint_char_fg}"
+	background = "${alac_toml_first_hint_char_bg}"
+	[colors.hints.end]
+	foreground = "${alac_toml_chars_after_first_hint_fg}"
+	background = "${alac_toml_chars_after_first_hint_bg}"
+	[colors.line_indicator]
+	foreground = "${alac_toml_line_indicator_fg}"
+	background = "${alac_toml_line_indicator_bg}"
+	[colors.footer_bar]
+	foreground = "${alac_toml_footer_fg}"
+	background = "${alac_toml_footer_bg}"
+	[colors.selection]
+	text = "${alac_toml_selection_fg}"
+	background = "${alac_toml_selection_bg}"
+	[colors.normal]
+	black = "${alac_toml_normal_black}"
+	red = "${alac_toml_normal_red}"
+	green = "${alac_toml_normal_green}"
+	yellow = "${alac_toml_normal_yellow}"
+	blue = "${alac_toml_normal_blue}"
+	magenta = "${alac_toml_normal_magenta}"
+	cyan = "${alac_toml_normal_cyan}"
+	white = "${alac_toml_normal_white}"
+	[colors.bright]
+	black = "${alac_toml_bright_black}"
+	red = "${alac_toml_bright_red}"
+	green = "${alac_toml_bright_green}"
+	yellow = "${alac_toml_bright_yellow}"
+	blue = "${alac_toml_bright_blue}"
+	magenta = "${alac_toml_bright_magenta}"
+	cyan = "${alac_toml_bright_cyan}"
+	white = "${alac_toml_bright_white}"
+	[colors.dim]
+	black = "${alac_toml_dim_black}"
+	red = "${alac_toml_dim_red}"
+	green = "${alac_toml_dim_green}"
+	yellow = "${alac_toml_dim_yellow}"
+	blue = "${alac_toml_dim_blue}"
+	magenta = "${alac_toml_dim_magenta}"
+	cyan = "${alac_toml_dim_cyan}"
+	white = "${alac_toml_dim_white}"
+]],
+	alacritty_toml_colors
 )
 
 nvim:interpolate(
@@ -1097,6 +1174,7 @@ set fish_pager_color_selected_completion ${fish_pager_selected_completion}
 return {
 	theme = nvim:render(),
 	alacritty = alacritty:render(),
+	alacritty_toml = alacritty_toml:render(),
 	fish = fish:render(),
 	lightline = lightline:render(),
 	docs = docs:render(),


### PR DESCRIPTION
Alacritty migrated from .yaml to .toml since YAML sucks even more than TOML I guess. So here's the same stuff but in a different format. Mesmerizing code.

The colors for the `interpolate` call for the `.toml` variant are generated by copying the colors for the `.yaml` version but adding a prefix to each key so `alac_primary_fg` becomes `alac_toml_primary_fg`
