### PR TITLE
Add @function.method.call

### DIFF
--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -241,6 +241,7 @@ if has('nvim')
 	hi! link @text.literal helpExample
 	hi! link @constant.builtin Constant
 	hi @function guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold
+	hi @function.method.call guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
 	hi @text.strong guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi @text.emphasis guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi @method guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -641,6 +641,7 @@ if has('nvim')
 	${@text.literal}
 	${@constant.builtin}
 	${@function}
+	${@function.method.call}
 	${@text.strong}
 	${@text.emphasis}
 	${@method}
@@ -714,6 +715,12 @@ endif
 			guifg = d:get("@text.strong", "guifg"),
 			guibg = d:get("@text.strong", "guibg"),
 			gui = d:get("@text.strong", "gui"),
+		},
+		["@function.method.call"] = hl {
+			"@function.method.call",
+			guifg = d:get("@method.call", "guifg"),
+			guibg = d:get("@method.call", "guibg"),
+			gui = d:get("@method.call", "gui"),
 		},
 		["@function.call"] = hl {
 			"@function.call",


### PR DESCRIPTION
Suddenly too many things are underlined and I think it's because this
group is now active but not defined and it defaults to the declaration
group which underlines the function name
