### PR TITLE
Update Haskell colors

### DIFF
--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -241,6 +241,7 @@ if has('nvim')
 	hi! link @text.literal helpExample
 	hi! link @constant.builtin Constant
 	hi @function guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold
+	hi @function.method.call guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=italic cterm=italic
 	hi @text.strong guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi @text.emphasis guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi @method guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=underline,bold cterm=underline,bold

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -237,6 +237,12 @@ if has('nvim')
 	let g:terminal_color_14 = '#377166'
 	let g:terminal_color_15 = '#e4dbdb'
 
+	hi @function.haskell guifg=#504944 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+	hi @variable.haskell guifg=#504944 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+	hi @variable.parameter.haskell guifg=#504944 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+	hi @keyword.haskell guifg=#504944 ctermfg=239 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+	hi @operator.haskell guifg=#504944 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+
 	hi @keyword.coroutine guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi! link @text.literal helpExample
 	hi! link @constant.builtin Constant

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -641,6 +641,7 @@ if has('nvim')
 	${@text.literal}
 	${@constant.builtin}
 	${@function}
+	${@function.method.call}
 	${@text.strong}
 	${@text.emphasis}
 	${@method}
@@ -714,6 +715,12 @@ endif
 			guifg = d:get("@text.strong", "guifg"),
 			guibg = d:get("@text.strong", "guibg"),
 			gui = d:get("@text.strong", "gui"),
+		},
+		["@function.method.call"] = hl {
+			"@function.method.call",
+			guifg = d:get("@method.call", "guifg"),
+			guibg = d:get("@method.call", "guibg"),
+			gui = d:get("@method.call", "gui"),
 		},
 		["@function.call"] = hl {
 			"@function.call",

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -637,6 +637,12 @@ if has('nvim')
 	let g:terminal_color_14 = '${term_bright_cyan}'
 	let g:terminal_color_15 = '${term_bright_white}'
 
+	${@function.haskell}
+	${@variable.haskell}
+	${@variable.parameter.haskell}
+	${@keyword.haskell}
+	${@operator.haskell}
+
 	${@keyword.coroutine}
 	${@text.literal}
 	${@constant.builtin}
@@ -727,6 +733,36 @@ endif
 			guifg = d:get("@method.call", "guifg"),
 			guibg = d:get("@method.call", "guibg"),
 			gui = d:get("@method.call", "gui"),
+		},
+		["@operator.haskell"] = hl {
+			"@operator.haskell",
+			guifg = d:get("Normal", "guifg"),
+			guibg = "NONE",
+			gui = { "NONE" },
+		},
+		["@variable.parameter.haskell"] = hl {
+			"@variable.parameter.haskell",
+			guifg = d:get("Normal", "guifg"),
+			guibg = "NONE",
+			gui = { "NONE" },
+		},
+		["@keyword.haskell"] = hl {
+			"@keyword.haskell",
+			guifg = d:get("Normal", "guifg"),
+			guibg = "NONE",
+			gui = { "bold" },
+		},
+		["@variable.haskell"] = hl {
+			"@variable.haskell",
+			guifg = d:get("Normal", "guifg"),
+			guibg = "NONE",
+			gui = { "NONE" },
+		},
+		["@function.haskell"] = hl {
+			"@function.haskell",
+			guifg = d:get("Normal", "guifg"),
+			guibg = "NONE",
+			gui = "NONE",
 		},
 		["@symbol"] = hl {
 			"@symbol",


### PR DESCRIPTION
Haskell looks very noisy since with Treesitter it doesn't seem to differentiate between function decls and calls so I toned it down a bit. Here's a before and after
![Screenshot 2024-04-17 at 09 14 16](https://github.com/cideM/yui/assets/4246921/1d7399e4-b132-4213-ac2c-ca0dbf1970f4)
![Screenshot 2024-04-17 at 09 14 37](https://github.com/cideM/yui/assets/4246921/e823ada1-bc47-4ea1-8b23-aff7146f32a8)
