### PR TITLE
Fix treesitter diff highlighting

### DIFF
--- a/alacritty/yui.yml
+++ b/alacritty/yui.yml
@@ -1,4 +1,4 @@
-{ 
+{
 	"colors": {
 		"primary": {
 			"foreground": "#504944",

--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -261,6 +261,9 @@ if has('nvim')
 	hi @keyword.function guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 	hi @keyword.operator guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
 	hi @keyword.return guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=bold cterm=bold
+	hi! link @diff.plus DiffAdd
+	hi! link @diff.minus DiffDelete
+	hi! link @diff.delta DiffChange
 
 	hi @lsp.type.function guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 	hi @lsp.type.method guifg=fg ctermfg=fg guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/src/yui.lua
+++ b/src/yui.lua
@@ -153,7 +153,7 @@ local alacritty_colors = {
 
 alacritty:interpolate(
 	[[
-{ 
+{
 	"colors": {
 		"primary": {
 			"foreground": "${alac_primary_fg}",
@@ -661,6 +661,9 @@ if has('nvim')
 	${@keyword.function}
 	${@keyword.operator}
 	${@keyword.return}
+	${@diff.plus}
+	${@diff.minus}
+	${@diff.delta}
 
 	${@lsp.type.function}
 	${@lsp.type.method}
@@ -822,6 +825,18 @@ endif
 			guifg = d:get("@lsp.typemod.member.declaration", "guifg"),
 			guibg = d:get("@lsp.typemod.member.declaration", "guibg"),
 			gui = d:get("@lsp.typemod.member.declaration", "gui"),
+		},
+		["@diff.plus"] = hl {
+			"@diff.plus",
+			link = "DiffAdd",
+		},
+		["@diff.minus"] = hl {
+			"@diff.minus",
+			link = "DiffDelete",
+		},
+		["@diff.delta"] = hl {
+			"@diff.delta",
+			link = "DiffChange",
 		},
 		["@namespace.builtin"] = hl {
 			"@namespace.builtin",


### PR DESCRIPTION
Recently I noticed diff's stopped highlighting properly when using `git commit --verbose`. 

I think an nvim-treesitter update broke them, these appear to be the new capture names:
https://github.com/nvim-treesitter/nvim-treesitter/commit/1ae9b0e4558fe7868f8cda2db65239cfb14836d0