### PR TITLE
Detect dark or light mode based on terminal background

### DIFF
--- a/colors/yui.vim
+++ b/colors/yui.vim
@@ -1,0 +1,17 @@
+if (!has('gui_running') && &t_Co < 256 && !has('nvim'))
+  finish
+endif
+
+hi clear
+
+if exists('syntax_on')
+  syntax reset
+endif
+
+let g:colors_name = 'yui'
+let script_dir = fnamemodify(expand('<sfile>:p'), ':h')
+if &background == 'dark'
+  execute 'source ' . script_dir . '/yui_dark.vim'
+else
+  execute 'source ' . script_dir . '/yui_light.vim'
+endif

--- a/colors/yui_dark.vim
+++ b/colors/yui_dark.vim
@@ -1,16 +1,14 @@
-	set background=light
-
 	if (!has('gui_running') && &t_Co < 256 && !has('nvim'))
 		finish
 	endif
-
-	hi clear
 
 	if exists('syntax_on')
 		syntax reset
 	endif
 
-	let g:colors_name = 'yui_dark'
+  if exists('g:colors_name') && g:colors_name != 'yui'
+    let g:colors_name = 'yui_dark'
+  endif
 
 	hi Normal guifg=#aaaab5 ctermfg=145 guibg=#1F1F29 ctermbg=235
 	hi! link NormalNC Normal

--- a/colors/yui_light.vim
+++ b/colors/yui_light.vim
@@ -1,16 +1,14 @@
-	set background=light
-
 	if (!has('gui_running') && &t_Co < 256 && !has('nvim'))
 		finish
 	endif
-
-	hi clear
 
 	if exists('syntax_on')
 		syntax reset
 	endif
 
-	let g:colors_name = 'yui'
+  if exists('g:colors_name') && g:colors_name != 'yui'
+    let g:colors_name = 'yui_light'
+  endif
 
 	hi Normal guifg=#3D3C44 ctermfg=238 guibg=#F1EDED ctermbg=255
 	hi! link NormalNC Normal

--- a/doc/yui.txt
+++ b/doc/yui.txt
@@ -3,6 +3,28 @@
 YUI | ユイ
 
 ==============================================================================
+LIGHT OR DARK
+
+yui ships with dark and light varients and chooses which to use based on what
+the *background* has been set to.
+
+Vim detects your light/dark setup automatically.
+
+	  Vim guesses the background color that you are using.  If it is black
+	  (or another dark color) it will use light colors for text.  If it is
+	  white (or another light color) it will use dark colors for text.
+
+          See Using syntax highlighting section *06.2*
+
+If you think detection failed or have a preference, you can set this yourself
+by setting this in your .vimrc or live:
+
+>
+        :set background=dark
+        :set background=light
+<
+
+==============================================================================
 OPTIONS                                                              *OPTIONS*
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Yui ships with themes for both light and dark but they require that you specify a single colour scheme. Built in vim themes do not need this, they adjust based on the setting of the &background property.

Vim and Neovim detect and call :set background=light or =dark depending on currently set terminal theme. This gets quite interesting when you set system preferences to dark/light based on the time of day.

Would love feedback. Is this something you'd want?

If you have future bugs related to this, feel free to tag me and I'll help you keep this working.

## Testing

Vim dark

![YUI dark theme in Vim](https://github.com/user-attachments/assets/1b17a7a0-2419-4d20-947b-7c5f747bfb4a)

Vim light

![YUI light theme in Vim](https://github.com/user-attachments/assets/b1f4bc50-9f4b-4f81-87a6-0d0f4cc7dd4b)

And I've kicked the tyres on neovim too:
![nvim dark](https://github.com/user-attachments/assets/51e97b83-c3b4-4ab7-ba2d-684d8e813935)
![nvim light](https://github.com/user-attachments/assets/4587a25f-6956-4487-87b8-637693290b3f)